### PR TITLE
fix: edit dialog

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/OfficeHoursNodeContent/OfficeHoursNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/OfficeHoursNodeContent/OfficeHoursNodeContent.tsx
@@ -1,6 +1,11 @@
 import { Stack, Tag, Text, Flex, Wrap } from '@chakra-ui/react'
 import { useTypebot } from 'contexts/TypebotContext'
-import { Comparison, ConditionItem, ComparisonOperators, OfficeHoursItem } from 'models'
+import {
+  Comparison,
+  ConditionItem,
+  ComparisonOperators,
+  OfficeHoursItem,
+} from 'models'
 import React from 'react'
 import { Container } from './OfficeHours.style'
 
@@ -9,15 +14,15 @@ type Props = {
 }
 
 export const OfficeHoursNodeContent = ({ item }: Props) => {
-  const { typebot } = useTypebot();
+  const { typebot } = useTypebot()
 
   return (
     <Container>
-      {item.content.values.map((value) => (
-        <>
-        {value === "@OFFICE_HOURS_TRUE" && "Dentro do expediente"}
-        {value === "@OFFICE_HOURS_FALSE" && "Fora do expediente"}
-        </>
+      {item.content.values.map((value, idx) => (
+        <div key={idx}>
+          {value === '@OFFICE_HOURS_TRUE' && 'Dentro do expediente'}
+          {value === '@OFFICE_HOURS_FALSE' && 'Fora do expediente'}
+        </div>
       ))}
     </Container>
   )

--- a/apps/builder/pages/typebots/[typebotId]/edit.tsx
+++ b/apps/builder/pages/typebots/[typebotId]/edit.tsx
@@ -1,13 +1,11 @@
 import { Flex } from '@chakra-ui/layout'
 import { Seo } from 'components/Seo'
-//import hash from 'object-hash'
 import {
   EditorContext,
   RightPanel as RightPanelEnum,
   useEditor,
 } from 'contexts/EditorContext'
-import { useEffect, useRef, useState, useMemo } from 'react'
-import { KBar } from 'components/shared/KBar'
+import { useEffect } from 'react'
 import { BoardMenuButton } from 'components/editor/BoardMenuButton'
 import { PreviewDrawer } from 'components/editor/preview/PreviewDrawer'
 import { StepsSideBar } from 'components/editor/StepsSideBar'
@@ -16,49 +14,26 @@ import { GraphProvider } from 'contexts/GraphContext'
 import { GraphDndContext } from 'contexts/GraphDndContext'
 import { useTypebot } from 'contexts/TypebotContext'
 import { GettingStartedModal } from 'components/editor/GettingStartedModal'
-
-// import { CustomFieldTitle } from 'enums/customFieldsTitlesEnum'
-// import CustomFields from 'services/octadesk/customFields/customFields'
-// import { DomainType } from 'enums/customFieldsEnum'
-// import cuid from 'cuid'
-// import {
-//   fixedChatProperties,
-//   fixedOrganizationProperties,
-//   fixedPersonProperties,
-// } from 'helpers/presets/variables-presets'
+import { dequal } from 'dequal'
 
 function TypebotEditPage() {
-  const { typebot, isReadOnly, save, createVariable, deleteVariable } = useTypebot()
-
-  const [typebotInitialUpdatedAt, setTypebotInitialUpdatedAt] =
-    useState<any>(null)
-  const updatedTypebot = useRef(false)
+  const { typebot, isReadOnly, save, currentTypebot } = useTypebot()
 
   useEffect(() => {
     window.addEventListener('message', handleEventListeners)
 
-    // return () => window.removeEventListener('message', handleEventListeners)
-  }, [])
+    return () => window.removeEventListener('message', handleEventListeners)
+  }, [typebot])
 
   useEffect(() => {
     window.parent.postMessage({ name: 'iFrameHasLoaded' }, '*')
-  
   }, [])
-  
-
-  useEffect(() => {
-    if (updatedTypebot.current) return
-
-    if (typebot && !typebotInitialUpdatedAt) {
-      setTypebotInitialUpdatedAt(typebot.updatedAt)
-    } else if (typebot && typebot.updatedAt !== typebotInitialUpdatedAt) {
-      updatedTypebot.current = true
-    }
-  }, [typebot])
 
   const handleEventListeners = (e: any): void => {
-    if (e.data === 'backClick') {
-      if (updatedTypebot.current) {
+    if (e.data === 'backOrExitClick') {
+      const hasUnsavedChanges = dequal(typebot?.blocks, currentTypebot?.blocks)
+
+      if (!hasUnsavedChanges) {
         const botEditedMessage = Object.assign({
           name: 'botEditedCannotSave',
         })
@@ -73,12 +48,8 @@ function TypebotEditPage() {
       }
     }
     if (e.data.name === 'saveClick') {
-
       save(e.data.personaName, e.data.personaThumbUrl).then((res) => {
         if (res.saved) {
-          updatedTypebot.current = false
-          setTypebotInitialUpdatedAt(res.updatedAt)
-
           const data = Object.assign({
             name: 'successSave',
           })
@@ -101,7 +72,6 @@ function TypebotEditPage() {
     <>
       <EditorContext>
         <Seo title="Editor" />
-        {/* <KBar /> */}
         <Flex overflow="clip" h="100vh" flexDir="column" id="editor-container">
           <GettingStartedModal />
           <Flex


### PR DESCRIPTION
# Description

Whenever the user exited the v2 bot edit, there was a dialog being prompted sometimes even if the user didn't make any changes, this PR fixes that not only not showing the default dialog but showing our modal with the buttons working correctly, exit without saving, save and close. 

Fixes # [(issue)](https://octadesk1614602251.atlassian.net/browse/OCTA-5512)
Relates to # (pull request number)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

QA

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works :NERVOSO:
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
