### PR TITLE
fix: show on portuguese and save the enum value for comparison

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ConditionNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ConditionNodeContent.tsx
@@ -1,6 +1,6 @@
 import { Stack, Tag, Text, Flex, Wrap } from '@chakra-ui/react'
 import { useTypebot } from 'contexts/TypebotContext'
-import { Comparison, ConditionItem, ComparisonOperators } from 'models'
+import { Comparison, ConditionItem, ComparisonOperators, LogicalOperator } from 'models'
 import React from 'react'
 import { byId, isNotDefined } from 'utils'
 
@@ -13,7 +13,7 @@ export const ConditionNodeContent = ({ item }: Props) => {
   return (
     <Flex px={2} py={2}>
       {item.content.comparisons.length === 0 ||
-      comparisonIsEmpty(item.content.comparisons[0]) ? (
+        comparisonIsEmpty(item.content.comparisons[0]) ? (
         <Text color={'gray.500'}>Configuração...</Text>
       ) : (
         <Stack maxW="170px">
@@ -23,7 +23,7 @@ export const ConditionNodeContent = ({ item }: Props) => {
             )
             return (
               <Wrap key={comparison.id} spacing={1} noOfLines={0}>
-                {idx > 0 && <Text>{item.content.logicalOperator ?? ''}</Text>}
+                {idx > 0 && <Text>{parseLogicalOperatorSymbol(item.content.logicalOperator) ?? ''}</Text>}
                 {variable?.token && (
                   <Tag bgColor="orange.400" color="white">
                     {variable.token}
@@ -55,10 +55,18 @@ const comparisonIsEmpty = (comparison: Comparison) =>
   isNotDefined(comparison.value) &&
   isNotDefined(comparison.variableId)
 
+const parseLogicalOperatorSymbol = (operator: LogicalOperator) => {
+  const toCompare = Object.keys(LogicalOperator).indexOf(operator)
+  return Object.values(LogicalOperator)[toCompare]
+}
+
+
 const parseComparisonOperatorSymbol = (operator: ComparisonOperators) => {
-  switch (operator) {
+  const toCompare = Object.keys(ComparisonOperators).indexOf(operator)
+  console.log('parseComparisonOperatorSymbol', { toCompare, operator })
+  switch (Object.values(ComparisonOperators)[toCompare]) {
     case ComparisonOperators.CONTAINS:
-      return 'contains'
+      return 'contém'
     case ComparisonOperators.EQUAL:
       return '='
     case ComparisonOperators.GREATER:

--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ConditionNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ConditionNodeContent.tsx
@@ -63,8 +63,8 @@ const parseComparisonOperatorSymbol = (operator: ComparisonOperators) => {
       return '='
     case ComparisonOperators.GREATER:
       return '>'
-    case ComparisonOperators.IS_SET:
-      return 'is set'
+    // case ComparisonOperators.IS_SET:
+    //   return 'is set'
     case ComparisonOperators.LESS:
       return '<'
     case ComparisonOperators.NOT_EQUAL:

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/ConditionSettingsBody/ComparisonsItem.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/ConditionSettingsBody/ComparisonsItem.tsx
@@ -17,12 +17,22 @@ export const ComparisonItem = ({
   const handleSelectComparisonOperator = (
     comparisonOperator: ComparisonOperators
   ) => {
-    if (comparisonOperator === item.comparisonOperator) return
-    onItemChange({ ...item, comparisonOperator })
+    const indexOf = Object.values(ComparisonOperators).indexOf(comparisonOperator)
+    const val = Object.keys(ComparisonOperators)[indexOf]
+
+    if (val === item.comparisonOperator) return
+    onItemChange({ ...item, comparisonOperator: val as ComparisonOperators })
   }
   const handleChangeValue = (value: string) => {
     if (value === item.value) return
     onItemChange({ ...item, value })
+  }
+
+  const showCorrectInput = (value: ComparisonOperators | undefined) => {
+    if (!value) return
+
+    const indexOf = Object.keys(ComparisonOperators).indexOf(value)
+    return Object.values(ComparisonOperators)[indexOf]
   }
 
   return (
@@ -33,18 +43,16 @@ export const ComparisonItem = ({
         placeholder="Pesquise sua variável"
       />
       <DropdownList<ComparisonOperators>
-        currentItem={item.comparisonOperator}
+        currentItem={showCorrectInput(item.comparisonOperator)}
         onItemSelect={handleSelectComparisonOperator}
         items={Object.values(ComparisonOperators)}
         placeholder="Selecione um operador"
       />
-      {item.comparisonOperator !== ComparisonOperators.IS_SET && (
-        <Input
-          defaultValue={item.value ?? ''}
-          onChange={handleChangeValue}
-          placeholder="Digite um valor..."
-        />
-      )}
+      <Input
+        defaultValue={item.value ?? ''}
+        onChange={handleChangeValue}
+        placeholder="Digite um valor..."
+      />
     </Stack>
   )
 }

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/ConditionSettingsBody/ConditonSettingsBody.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/ConditionSettingsBody/ConditonSettingsBody.tsx
@@ -24,7 +24,19 @@ export const ConditionSettingsBody = ({
   const handleComparisonsChange = (comparisons: Comparison[]) =>
     onItemChange({ content: { ...itemContent, comparisons } })
   const handleLogicalOperatorChange = (logicalOperator: LogicalOperator) =>
-    onItemChange({ content: { ...itemContent, logicalOperator } })
+  {
+    const indexOf = Object.values(LogicalOperator).indexOf(logicalOperator)
+    const val = Object.keys(LogicalOperator)[indexOf]
+    onItemChange({ content: { ...itemContent, logicalOperator: val as LogicalOperator } })
+  }
+
+  const showCorrectInput = (value: LogicalOperator | undefined) => {
+    if (!value) return
+
+    const indexOf = Object.keys(LogicalOperator).indexOf(value)
+    return Object.values(LogicalOperator)[indexOf]
+  }
+    
 
   return (
     <TableList<Comparison>
@@ -34,7 +46,7 @@ export const ConditionSettingsBody = ({
       ComponentBetweenItems={() => (
         <Flex justify="center">
           <DropdownList<LogicalOperator>
-            currentItem={itemContent.logicalOperator}
+            currentItem={showCorrectInput(itemContent.logicalOperator)}
             onItemSelect={handleLogicalOperatorChange}
             items={Object.values(LogicalOperator)}
             mb="4"

--- a/packages/bot-engine/src/services/logic.ts
+++ b/packages/bot-engine/src/services/logic.ts
@@ -115,9 +115,9 @@ const executeComparison =
       case ComparisonOperators.LESS: {
         return parseFloat(inputValue) <= parseFloat(value)
       }
-      case ComparisonOperators.IS_SET: {
-        return isDefined(inputValue) && inputValue.length > 0
-      }
+      // case ComparisonOperators.IS_SET: {
+      //   return isDefined(inputValue) && inputValue.length > 0
+      // }
     }
   }
 

--- a/packages/models/src/typebot/steps/logic.ts
+++ b/packages/models/src/typebot/steps/logic.ts
@@ -59,7 +59,7 @@ export enum LogicalOperator {
 
 export enum ComparisonOperators {
   EQUAL = 'Igual a',
-  NOT_EQUAL = 'Diferente',
+  NOT_EQUAL = 'Diferente de',
   CONTAINS = 'Contém',
   GREATER = 'Maior que',
   LESS = 'Menor que',

--- a/packages/models/src/typebot/steps/logic.ts
+++ b/packages/models/src/typebot/steps/logic.ts
@@ -63,7 +63,7 @@ export enum ComparisonOperators {
   CONTAINS = 'Contém',
   GREATER = 'Maior que',
   LESS = 'Menor que',
-  IS_SET = 'Está configurado',
+  //IS_SET = 'Está configurado',
 }
 
 export type ConditionContent = {

--- a/packages/models/src/typebot/steps/logic.ts
+++ b/packages/models/src/typebot/steps/logic.ts
@@ -103,7 +103,7 @@ export const defaultSetVariablesOptions: SetVariableOptions = {}
 
 export const defaultConditionContent: ConditionContent = {
   comparisons: [],
-  logicalOperator: LogicalOperator.AND,
+  logicalOperator: 'AND' as LogicalOperator,
 }
 
 export const defaultRedirectOptions: RedirectOptions = { isNewTab: false }


### PR DESCRIPTION
# Description

After translation, the comparison component was broken. This aim to always send the ENUM value and not the text for comparison and logical operators

EXTRA: remove the IS_SET Comparison that we do not have on bot-service

Fixes # (issue)
Relates to # (pull request number)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local and qas

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works :NERVOSO:
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
