### PR TITLE
fix: do not show warning for event flow bot

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
@@ -50,6 +50,12 @@ export const BlockNode = ({ block, blockIndex }: Props) => {
 
   const [isFocused, setIsFocused] = useState(false)
 
+  const availableOnlyForEvent =
+    typebot?.availableFor?.length == 1 &&
+    typebot.availableFor.includes('event')
+
+  const showWarning = !availableOnlyForEvent
+
   const isPreviewing =
     previewingEdge?.from.blockId === block.id ||
     (previewingEdge?.to.blockId === block.id &&
@@ -80,7 +86,7 @@ export const BlockNode = ({ block, blockIndex }: Props) => {
   useEffect(() => {
     setIsConnecting(
       connectingIds?.target?.blockId === block.id &&
-        isNotDefined(connectingIds.target?.stepId)
+      isNotDefined(connectingIds.target?.stepId)
     )
   }, [block.id, connectingIds])
 
@@ -134,7 +140,7 @@ export const BlockNode = ({ block, blockIndex }: Props) => {
   const onDragStop = () => setIsMouseDown(false)
 
   const stackBorderColor = (isOpened: boolean): string => {
-    if (!block.hasConnection) {
+    if (!block.hasConnection && showWarning) {
       return 'yellow.500'
     } else if (isConnecting || isOpened || isPreviewing || isFocused) {
       return 'blue.400'
@@ -143,7 +149,7 @@ export const BlockNode = ({ block, blockIndex }: Props) => {
     return '#ffffff'
   }
 
-  const showEmptyConnectionAlert = () => !block.hasConnection
+  const showEmptyConnectionAlert = () => !block.hasConnection && showWarning
 
   return (
     <ContextMenu<HTMLDivElement>
@@ -171,9 +177,8 @@ export const BlockNode = ({ block, blockIndex }: Props) => {
               transition="border 300ms, box-shadow 200ms"
               pos="absolute"
               style={{
-                transform: `translate(${blockCoordinates?.x ?? 0}px, ${
-                  blockCoordinates?.y ?? 0
-                }px)`,
+                transform: `translate(${blockCoordinates?.x ?? 0}px, ${blockCoordinates?.y ?? 0
+                  }px)`,
               }}
               onMouseDown={handleMouseDown}
               onMouseEnter={handleMouseEnter}

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -232,7 +232,7 @@ export const StepNode = ({
                           data-testid={`${step.id}-icon`}
                         />
                         <Spacer />
-                        {showWarning && (
+                        {unreachableNode && showWarning && (
                           <>
                             <OctaTooltip
                               element={<WarningIcon color={'#FAC300'} />}

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -81,15 +81,22 @@ export const StepNode = ({
     setFocusedBlockId,
     previewingEdge,
   } = useGraph()
-  const { updateStep } = useTypebot()
+  const { updateStep, typebot } = useTypebot()
   const [isConnecting, setIsConnecting] = useState(false)
+
+
+  const availableOnlyForEvent =
+    typebot?.availableFor?.length == 1 &&
+    typebot.availableFor[0] == 'event'
+
+  const showWarning = unreachableNode && !availableOnlyForEvent
 
   const [isPopoverOpened, setIsPopoverOpened] = useState(
     openedStepId === step.id
   )
   const [isEditing, setIsEditing] = useState<boolean>(
     (isTextBubbleStep(step) || isOctaBubbleStep(step)) &&
-      step.content.plainText === ''
+    step.content.plainText === ''
   )
   const stepRef = useRef<HTMLDivElement | null>(null)
 
@@ -127,7 +134,7 @@ export const StepNode = ({
   useEffect(() => {
     setIsConnecting(
       connectingIds?.target?.blockId === step.blockId &&
-        connectingIds?.target?.stepId === step.id
+      connectingIds?.target?.stepId === step.id
     )
   }, [connectingIds, step.blockId, step.id])
 
@@ -212,7 +219,7 @@ export const StepNode = ({
                   <BlockStack
                     isOpened={isOpened}
                     isPreviewing={isPreviewing}
-                    style={{ borderColor: unreachableNode ? '#e3a820' : '' }}
+                    style={{ borderColor: showWarning ? '#e3a820' : '' }}
                   >
                     <Stack spacing={2} w="full">
                       <HStack fontSize={'14px'}>
@@ -226,7 +233,7 @@ export const StepNode = ({
                           data-testid={`${step.id}-icon`}
                         />
                         <Spacer />
-                        {unreachableNode && (
+                        {showWarning && (
                           <>
                             <OctaTooltip
                               element={<WarningIcon color={'#FAC300'} />}

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -214,6 +214,7 @@ export const StepNode = ({
                 w="full"
                 direction="column"
               >
+
                 <Stack spacing={2}>
                   <BlockStack
                     isOpened={isOpened}

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -84,10 +84,11 @@ export const StepNode = ({
   const { updateStep, typebot } = useTypebot()
   const [isConnecting, setIsConnecting] = useState(false)
 
+  debugger
 
   const availableOnlyForEvent =
     typebot?.availableFor?.length == 1 &&
-    typebot.availableFor[0] == 'event'
+    typebot.availableFor.includes('event')
 
   const showWarning = unreachableNode && !availableOnlyForEvent
 

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -88,7 +88,7 @@ export const StepNode = ({
     typebot?.availableFor?.length == 1 &&
     typebot.availableFor.includes('event')
 
-  const showWarning = unreachableNode && !availableOnlyForEvent
+  const showWarning = !availableOnlyForEvent
 
   const [isPopoverOpened, setIsPopoverOpened] = useState(
     openedStepId === step.id
@@ -218,7 +218,7 @@ export const StepNode = ({
                   <BlockStack
                     isOpened={isOpened}
                     isPreviewing={isPreviewing}
-                    style={{ borderColor: showWarning ? '#e3a820' : '' }}
+                    style={{ borderColor: unreachableNode && showWarning ? '#e3a820' : '' }}
                   >
                     <Stack spacing={2} w="full">
                       <HStack fontSize={'14px'}>
@@ -246,7 +246,7 @@ export const StepNode = ({
                             />
                           </>
                         )}
-                        {!unreachableNode && validationMessages?.length &&
+                        {!unreachableNode && showWarning &&
                           validationMessages?.map((s, index) => {
                             return (
                               <OctaTooltip

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -84,8 +84,6 @@ export const StepNode = ({
   const { updateStep, typebot } = useTypebot()
   const [isConnecting, setIsConnecting] = useState(false)
 
-  debugger
-
   const availableOnlyForEvent =
     typebot?.availableFor?.length == 1 &&
     typebot.availableFor.includes('event')
@@ -248,7 +246,7 @@ export const StepNode = ({
                             />
                           </>
                         )}
-                        {!unreachableNode &&
+                        {!unreachableNode && validationMessages?.length &&
                           validationMessages?.map((s, index) => {
                             return (
                               <OctaTooltip


### PR DESCRIPTION
# Description

On event flow, the unreachable node makes no sense.

Fixes # (issue)
Relates to # (pull request number)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local and qas

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works :NERVOSO:
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
