### PR TITLE
fix: show return map on webhook

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WebhookSettings/WebhookSettings.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WebhookSettings/WebhookSettings.tsx
@@ -460,7 +460,7 @@ export const WebhookSettings = ({ step, onOptionsChange }: Props) => {
                 <label>{step.options.url ?? ''}</label>
                 <Textarea
                   placeholder=""
-                  onKeyDown={handleKeyDown as never}
+                  onKeyDown={handleKeyDown as any}
                   defaultValue={pathPortion ?? ''}
                   handleOpenVariablesSelect={variablesKeyDown}
                   onChange={handlePathChange}
@@ -482,7 +482,7 @@ export const WebhookSettings = ({ step, onOptionsChange }: Props) => {
                 (ex.:https://apiurl.com/<strong>?cep=#cep</strong>)
               </Text>
               <TableList<QueryParameters>
-                initialItems={step.options.parameters as never}
+                initialItems={step.options.parameters as any}
                 onItemsChange={handleQueryParamsChange}
                 Item={QueryParamsInputs}
                 itemsList={step.options.parameters}
@@ -503,7 +503,7 @@ export const WebhookSettings = ({ step, onOptionsChange }: Props) => {
                 <strong> (ex.: Authorization: Basic 1234)</strong>
               </Text>
               <TableList<QueryParameters>
-                initialItems={step.options.headers as never}
+                initialItems={step.options.headers as any}
                 onItemsChange={handleHeadersChange}
                 Item={QueryParamsInputs}
                 addLabel="Adicionar parâmetro"
@@ -558,7 +558,7 @@ export const WebhookSettings = ({ step, onOptionsChange }: Props) => {
             </AccordionButton>
             <AccordionPanel pb={4} as={Stack} spacing="6">
               <TableList<VariableForTest>
-                initialItems={step.options?.variablesForTest as never}
+                initialItems={step.options?.variablesForTest as any}
                 onItemsChange={handleVariablesForTestChange}
                 itemsList={step.options.variablesForTest}
                 Item={VariableForTestInputs}
@@ -614,7 +614,7 @@ export const WebhookSettings = ({ step, onOptionsChange }: Props) => {
               </AccordionButton>
               <AccordionPanel pb={4} as={Stack} spacing="6">
                 <TableList<ResponseVariableMapping>
-                  initialItems={step.options.responseVariableMapping as never}
+                  initialItems={step.options.responseVariableMapping as any}
                   onItemsChange={handleResponseMappingChange}
                   Item={ResponseMappingInputs}
                   addLabel="Adicionar variável"


### PR DESCRIPTION
# Description

Fixing problem when showing data saved on webhook after first save.

Fixes # (issue)
Relates to # (pull request number)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local and qas

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works :NERVOSO:
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
