### PR TITLE
fix: set limit to 3 buttons in waba

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/WhatsAppButtonsContent/WhatsAppButtonsNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/WhatsAppButtonsContent/WhatsAppButtonsNodeContent.tsx
@@ -28,6 +28,7 @@ export const WhatsAppButtonsNodeContent = ({
   const [initialContent] = useState(item.content ?? '')
   const [itemValue, setItemValue] = useState(item.content ?? 'Editar botão')
   const editableRef = useRef<HTMLDivElement | null>(null)
+  const MAX_BUTTON_LIMIT = 3
 
   useEffect(() => {
     if (itemValue !== item.content) setItemValue(item.content ?? 'Editar botão')
@@ -50,14 +51,17 @@ export const WhatsAppButtonsNodeContent = ({
   }
 
   const handlePlusClick = () => {
-    const itemIndex = indices.itemIndex + 1
-    createItem(
-      {
-        stepId: item.stepId,
-        type: ItemType.WHATSAPP_BUTTONS_LIST as ItemType.BUTTON,
-      },
-      { ...indices, itemIndex }
-    )
+    const itemCount = indices.itemsCount ?? 0
+    if (itemCount < MAX_BUTTON_LIMIT) {
+      const itemIndex = indices.itemIndex + 1
+      createItem(
+        {
+          stepId: item.stepId,
+          type: ItemType.WHATSAPP_BUTTONS_LIST as ItemType.BUTTON,
+        },
+        { ...indices, itemIndex }
+      )
+    }
   }
 
   const handleDeleteClick = () => {
@@ -111,6 +115,7 @@ export const WhatsAppButtonsNodeContent = ({
           shadow="md"
           colorScheme="gray"
           onClick={handlePlusClick}
+          isDisabled={(indices.itemsCount ?? 0) >= MAX_BUTTON_LIMIT}
         />
         {hasMoreThanOneItem() && (
           <IconButton


### PR DESCRIPTION
# Description

This fix is to limit the number of buttons in the option: "Pergunta com lista de botões", when it's more than 3 buttons, it breaks the footer in the component. Because of that, we decided to limit the number of buttons.

Fixes # [SST-319](https://octadesk1614602251.atlassian.net/browse/SST-319)

## Type of change

Fix

# How has this been tested?

It was tested on QA, trying to add more than 3 buttons
![image](https://github.com/user-attachments/assets/12643cef-8d55-4f44-a272-a3214474aeb1)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated [Mapeamento](https://docs.google.com/spreadsheets/d/1i6yP07og51aktbzKs-YVXlsvB1gCGHKPxn06HspTNto) with any new dependency


[SST-319]: https://octadesk1614602251.atlassian.net/browse/SST-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ