### PR TITLE
fix: alter from float to number

### DIFF
--- a/apps/builder/components/shared/VariableSearchInput/VariableSearchInput.tsx
+++ b/apps/builder/components/shared/VariableSearchInput/VariableSearchInput.tsx
@@ -219,23 +219,23 @@ export const VariableSearchInput = ({
     const { value } = e.target
     setCustomVariable(
       (state): Variable =>
-        ({
-          ...state,
-          token: value,
-          fieldId: value.replace('#', ''),
-          name: value.replace('#', ''),
-          domain: 'CHAT',
-        } as Variable)
+      ({
+        ...state,
+        token: value,
+        fieldId: value.replace('#', ''),
+        name: value.replace('#', ''),
+        domain: 'CHAT',
+      } as Variable)
     )
   }
 
   const handleSelectTypeVariable = (type: string) => {
     setCustomVariable(
       (state): Variable =>
-        ({
-          ...state,
-          type,
-        } as Variable)
+      ({
+        ...state,
+        type,
+      } as Variable)
     )
   }
 
@@ -330,8 +330,8 @@ export const VariableSearchInput = ({
                 dd/mm/aaaa
               </ButtonOption>
               <ButtonOption
-                className={customVariable?.type === 'float' ? 'active' : ''}
-                onClick={() => handleSelectTypeVariable('float')}
+                className={customVariable?.type === 'number' ? 'active' : ''}
+                onClick={() => handleSelectTypeVariable('number')}
               >
                 123
               </ButtonOption>


### PR DESCRIPTION
# Description

This problem is related with the way that numbers are treated on the flux of the conversation. On v1, when the user insert a new variable number, it saves as a "number" instead of "float". It makes the conversation follow the expected flux when the user types a wrong answer:
![image](https://github.com/user-attachments/assets/ccd1b35e-abc5-4813-af57-9f5d8583ee52)

In the v2, the number is treated as a float, but this breaks the flux:
![image](https://github.com/user-attachments/assets/f0eb38a1-6bab-4905-8f7f-6f08893a89e4)



Fixes # [SST-291](https://octadesk1614602251.atlassian.net/browse/SST-291)

## Type of change

Fix

## Breaking change

It fixing to follow the expected behavior of the bot conversation.

# How has this been tested?

It was tested on QA, trying to add new variables and saving the bot-build, to se if the type is being saved as "number":
![image](https://github.com/user-attachments/assets/e47042c9-7ec6-4e08-9691-595ee52f706f)
![image](https://github.com/user-attachments/assets/20d68a12-8072-4cc5-b9e8-387c16dca7d8)
![image](https://github.com/user-attachments/assets/0db826f1-c995-484f-858f-28c293268797)

Result:
![image](https://github.com/user-attachments/assets/9e2ec3c2-4877-4b67-b84e-f009be02a1d2)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated [Mapeamento](https://docs.google.com/spreadsheets/d/1i6yP07og51aktbzKs-YVXlsvB1gCGHKPxn06HspTNto) with any new dependency


[SST-291]: https://octadesk1614602251.atlassian.net/browse/SST-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ