### PR TITLE
fix: required fields on comparison items

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/ConditionSettingsBody/ComparisonsItem.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/ConditionSettingsBody/ComparisonsItem.tsx
@@ -1,4 +1,4 @@
-import { Stack, IconButton, Fade, Select } from '@chakra-ui/react'
+import { Stack, IconButton, Fade, Select, Flex } from '@chakra-ui/react'
 import { TrashIcon } from 'assets/icons'
 import { DropdownList } from 'components/shared/DropdownList'
 import { Input } from 'components/shared/Textbox/Input'
@@ -12,6 +12,7 @@ export const ComparisonItem = ({
   item,
   onItemChange,
   onRemoveItem,
+  required
 }: TableListItemProps<Comparison>) => {
   const { typebot, customVariables } = useTypebot()
   let myVariable = typebot?.variables?.find(
@@ -39,7 +40,7 @@ export const ComparisonItem = ({
   }
 
   const handleSelectComparisonOperator = (
-    comparisonOperator: ComparisonOperators
+    comparisonOperator: ComparisonOperators,
   ) => {
     const indexOf =
       Object.values(ComparisonOperators).indexOf(comparisonOperator)
@@ -172,12 +173,26 @@ export const ComparisonItem = ({
         placeholder="Pesquise sua variável"
         labelDefault="Se"
       />
+      {!item.variableId && (
+        <Flex color="red.400" fontSize="sm" mt={2}>
+          {typeof required === 'object'
+            ? required?.errorMsg
+            : 'É obrigatório selecionar uma variável'}
+        </Flex>
+      )}
       <DropdownList<ComparisonOperators>
         currentItem={showCorrectInput(item.comparisonOperator)}
         onItemSelect={handleSelectComparisonOperator}
         items={resolveOperators()}
         placeholder="Selecione um operador"
       />
+      {!item.comparisonOperator && (
+        <Flex color="red.400" fontSize="sm" mt={2}>
+          {typeof required === 'object'
+            ? required?.errorMsg
+            : 'É obrigatório selecionar um operador'}
+        </Flex>
+      )}
       {typeOfInputValue()}
       {needSecondaryValue && (
         <div>

--- a/apps/builder/components/shared/Graph/Nodes/helpers/helpers.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/helpers/helpers.tsx
@@ -1,6 +1,7 @@
 import {
   BubbleStepType,
   InputStepType,
+  LogicStepType,
   OctaBubbleStepType,
   OctaStepType,
   OctaWabaStepType,
@@ -110,6 +111,23 @@ export const getValidationMessages = (step: Step): Array<ValidationMessage> => {
         message: step?.content?.plainText,
         min: { value: -1 },
       })
+    }
+
+    if (LogicStepType.CONDITION === step.type) {
+      step?.items?.forEach((item) => {
+        if (item?.content?.comparisons) {
+          item.content.comparisons.forEach((comparison) => {
+            data.push(
+              {
+                message: comparison?.comparisonOperator
+              },
+              {
+                message: comparison?.variableId
+              },
+            );
+          });
+        }
+      });
     }
 
     if (inpuStepsWithFallbackMessages.includes(step.type)) {

--- a/apps/builder/components/shared/TableList.tsx
+++ b/apps/builder/components/shared/TableList.tsx
@@ -11,6 +11,7 @@ export type TableListItemProps<T> = {
   debounceTimeout?: number
   onItemChange: (item: T) => void
   onRemoveItem: (item: T) => void
+  required?: boolean | { errorMsg?: string }
 }
 
 type Props<T> = {


### PR DESCRIPTION
# Description

It's to check the comparator and variable field when user add a validation-field step on V2.

Fixes # ([SST-337](https://octadesk1614602251.atlassian.net/browse/CBM-362))

## Type of change

Fix

## Breaking change

Some fields are required now on the validation-field step

# How has this been tested?

It was tested on QA, implementing these requirements:
![image](https://github.com/user-attachments/assets/75e68fbc-a2a0-4928-927c-64dc06210525)
![image](https://github.com/user-attachments/assets/d14a5651-e6b8-4440-9004-a35de98c54a5)
![image](https://github.com/user-attachments/assets/ae7bff34-23f1-49a1-a421-e1ca28110414)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated [Mapeamento](https://docs.google.com/spreadsheets/d/1i6yP07og51aktbzKs-YVXlsvB1gCGHKPxn06HspTNto) with any new dependency


[CBM-362]: https://octadesk1614602251.atlassian.net/browse/CBM-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SST-337]: https://octadesk1614602251.atlassian.net/browse/SST-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ