### PR TITLE
fix: add selectOptions interative-list and interative-buttons

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/AssignToTeam/AssignToResponsibleSelect.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/AssignToTeam/AssignToResponsibleSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import OctaSelect from 'components/octaComponents/OctaSelect/OctaSelect'
 import { useTypebot } from 'contexts/TypebotContext'
 import { OptionType } from 'components/octaComponents/OctaSelect/OctaSelect.type'
@@ -87,6 +87,10 @@ export const AssignToResponsibleSelect = ({
     '@AGENT': (agent: IParsedAgents, options: IOptions) =>
       generateAgentValue(agent),
     '@GROUP': (agent: IParsedAgents, options: IOptions) =>
+      generateAgentValue(agent),
+    'interactive-list@AGENT': (agent: IParsedAgents, options: IOptions) =>
+      generateAgentValue(agent),
+    'interactive-buttons@AGENT': (agent: IParsedAgents, options: IOptions) =>
       generateAgentValue(agent),
   }
 


### PR DESCRIPTION
# Description

Assignment Value Not Visible when Reopening “Question with List of Options/Buttons” in Bot V2

## Type of change

- [x] fix

# How has this been tested?

![image](https://github.com/user-attachments/assets/3cd12965-b0cc-4142-99e3-ae5bdf7d0e7c)

![image](https://github.com/user-attachments/assets/cdddb079-dba2-4aee-aab0-8a1f37f627c8)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated [Mapeamento](https://docs.google.com/spreadsheets/d/1i6yP07og51aktbzKs-YVXlsvB1gCGHKPxn06HspTNto) with any new dependency
