### PR TITLE
fix: remove header text style if wabaHeader

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WhatsAppBodies/WhatsAppOptionsListSettings/WhatsAppOptionsListSettingsBody.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WhatsAppBodies/WhatsAppOptionsListSettings/WhatsAppOptionsListSettingsBody.tsx
@@ -9,7 +9,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { WhatsAppOptionsListOptions, Variable, TextBubbleContent } from 'models'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { TextBubbleEditor } from 'components/shared/Graph/Nodes/StepNode/TextBubbleEditor'
 import { VariableSearchInput } from 'components/shared/VariableSearchInput/VariableSearchInput'
 import { SlArrowDown, SlArrowUp } from 'react-icons/sl'
@@ -165,6 +165,7 @@ export const WhatsAppOptionsListSettingsBody = ({
           }
           onKeyUp={handleHeaderText}
           maxLength={MAX_LENGHT_HEADER_AND_FOOTER}
+          wabaHeader={true}
         />
       </Stack>
       <Stack>

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/TextBubbleEditor/TextBubbleEditor.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/TextBubbleEditor/TextBubbleEditor.tsx
@@ -35,6 +35,7 @@ type TextBubbleEditorProps = {
   maxLength?: number
   required?: boolean | { errorMsg?: string }
   menuPosition?: 'absolute' | 'fixed'
+  wabaHeader?: boolean
 }
 
 export const TextBubbleEditor = ({
@@ -45,6 +46,7 @@ export const TextBubbleEditor = ({
   maxLength,
   required,
   menuPosition = 'fixed',
+  wabaHeader,
 }: TextBubbleEditorProps) => {
   const [value, setValue] = useState(initialValue)
   const [focus, setFocus] = useState(false)
@@ -102,8 +104,19 @@ export const TextBubbleEditor = ({
 
         return
       }
+      if (wabaHeader) {
+        const lastNode = editor.children[editor.children.length - 1]
+        lastNode.children = [
+          {
+            text: lastNode.children
+              .map((children) => {
+                return children.text
+              })
+              .join(''),
+          },
+        ]
+      }
     }
-
     return editor
   }
   const closeEditor = () => {
@@ -246,6 +259,7 @@ export const TextBubbleEditor = ({
             setIsVariableDropdownOpen(showDialog)
           }}
           onEmojiSelected={handleEmoji}
+          wabaHeader={wabaHeader}
         />
         <Plate
           id={randomEditorId}

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/TextBubbleEditor/ToolBar.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/TextBubbleEditor/ToolBar.tsx
@@ -25,12 +25,14 @@ type Props = {
   editor: PlateEditor<Value>
   onVariablesButtonClick: (showDialog: boolean) => void
   onEmojiSelected: (emojiText: string) => void
+  wabaHeader?: boolean
 } & StackProps
 
 export const ToolBar = ({
   editor,
   onVariablesButtonClick,
   onEmojiSelected,
+  wabaHeader = false,
   ...props
 }: Props) => {
   const [showPicker, setShowPicker] = useState(false)
@@ -83,24 +85,30 @@ export const ToolBar = ({
       <Button size="sm" onMouseDown={handleVariablesButtonMouseDown}>
         Variáveis
       </Button>
-      <span data-testid="bold-button">
-        <MarkToolbarButton
-          type={getPluginType(editor, MARK_BOLD)}
-          icon={<BoldIcon fontSize="20px" />}
-        />
-      </span>
-      <span data-testid="italic-button">
-        <MarkToolbarButton
-          type={getPluginType(editor, MARK_ITALIC)}
-          icon={<ItalicIcon fontSize="20px" />}
-        />
-      </span>
-      <span data-testid="strikethrough-button">
-        <MarkToolbarButton
-          type={getPluginType(editor, MARK_STRIKETHROUGH)}
-          icon={<StrikethroughIcon fontSize="20px" />}
-        />
-      </span>
+      {!wabaHeader && (
+        <>
+          <span data-testid="bold-button">
+            <MarkToolbarButton
+              type={getPluginType(editor, MARK_BOLD)}
+              icon={<BoldIcon fontSize="20px" />}
+            />
+          </span>
+
+          <span data-testid="italic-button">
+            <MarkToolbarButton
+              type={getPluginType(editor, MARK_ITALIC)}
+              icon={<ItalicIcon fontSize="20px" />}
+            />
+          </span>
+
+          <span data-testid="strikethrough-button">
+            <MarkToolbarButton
+              type={getPluginType(editor, MARK_STRIKETHROUGH)}
+              icon={<StrikethroughIcon fontSize="20px" />}
+            />
+          </span>
+        </>
+      )}
       {workspace?.channel === 'web' && (
         <>
           <span data-testid="underline-button">


### PR DESCRIPTION
# Description

When you put one of the texts in the list of options in bold in bot v2, sending the message for this step generates an error

## Type of change

- [x] Fix

# How has this been tested?

![image](https://github.com/user-attachments/assets/1571becd-b961-4d19-8c0d-d5d12da44b70)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated [Mapeamento](https://docs.google.com/spreadsheets/d/1i6yP07og51aktbzKs-YVXlsvB1gCGHKPxn06HspTNto) with any new dependency
