### PR TITLE
feat: show inactive woz profile

### DIFF
--- a/apps/builder/components/octaComponents/OctaSelect/OctaSelect.style.ts
+++ b/apps/builder/components/octaComponents/OctaSelect/OctaSelect.style.ts
@@ -60,12 +60,12 @@ export const OptionItem = styled.li`
   &[data-isTitle] {
     font-weight: bold;
   }
-  &[data-disabled] {
-    &:hover {
-      background-color: transparent;
-    }
+  &.disabled {
+    color: #e0e1e6;
+    pointer-events: none;
+    background-color: #f4f4f5;
   }
-  &.actived {
+  &.actived:not(.disabled) {
     background-color: rgb(19, 102, 201);
     color: white;
   }

--- a/apps/builder/components/octaComponents/OctaSelect/OctaSelect.tsx
+++ b/apps/builder/components/octaComponents/OctaSelect/OctaSelect.tsx
@@ -49,11 +49,10 @@ const Option = ({
       key={optionKey}
       data-value={value}
       data-istitle={isTitle}
-      data-disabled={!!isTitle || disabled}
       onClick={hasActionToClick}
       className={`${children === selected?.label ? 'actived' : ''} ${
         isTitle ? 'isTitle' : ''
-      }`}
+      } ${!!isTitle || disabled ? 'disabled' : ''}`}
     >
       <>
         {children}

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WOZAssign/WozAssignSelect.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WOZAssign/WozAssignSelect.tsx
@@ -10,7 +10,8 @@ type Props = {
 }
 
 export const WozAssignSelect = ({ onSelect, selectedProfile }: Props) => {
-  const { wozProfiles } = useTypebot();
+  const { wozProfiles } = useTypebot()
+
   const [defaultSelected, setDefaultSelected] = useState<OptionType>()
 
   const handleOnChange = (selected: any): void => {
@@ -21,29 +22,39 @@ export const WozAssignSelect = ({ onSelect, selectedProfile }: Props) => {
     if (wozProfiles) {
       const defaultSelectedBot = wozProfiles.filter(
         (item) => (selectedProfile && item.id === selectedProfile) || item.isWoz
-      )[0];
+      )[0]
 
       if (defaultSelectedBot) {
+        const label = !defaultSelectedBot.active
+          ? `${defaultSelectedBot.label} (inativo)`
+          : defaultSelectedBot.label
+
         setDefaultSelected({
-          label: defaultSelectedBot.name,
+          label,
           value: {
-            botToCall: defaultSelectedBot.id
+            botToCall: defaultSelectedBot.id,
           },
-          key: ''
+          key: '',
         })
       }
     }
     return () => {
       setDefaultSelected(undefined)
-    };
+    }
   }, [wozProfiles, selectedProfile])
+
+  const parsedWozProfiles = wozProfiles.map((profile) => ({
+    ...profile,
+    disabled: !profile.active ? true : false,
+    label: !profile.active ? `${profile.label} (inativo)` : profile.label,
+  }))
 
   return (
     <OctaSelect
       placeholder="Selecione um perfil para atender"
       defaultSelected={defaultSelected}
       findable
-      options={wozProfiles}
+      options={parsedWozProfiles}
       onChange={handleOnChange}
     />
   )

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WOZAssign/WOZAssignContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WOZAssign/WOZAssignContent.tsx
@@ -1,9 +1,8 @@
 import { StepIndices, WOZAssignStep } from 'models'
 import React from 'react'
-import { Stack, Text, Tooltip } from '@chakra-ui/react'
+import { Stack, Text } from '@chakra-ui/react'
 import { ItemNodesList } from 'components/shared/Graph/Nodes/ItemNode'
 import { OctaDivider } from 'components/octaComponents/OctaDivider/OctaDivider'
-import OctaTooltip from 'components/octaComponents/OctaTooltip/OctaTooltip'
 import { useTypebot } from 'contexts/TypebotContext'
 
 type Props = {
@@ -13,28 +12,46 @@ type Props = {
 
 const WOZAssignContent = ({ step, indices }: Props) => {
   const { wozProfiles } = useTypebot()
-  const agent = wozProfiles.find(d => d.id === step?.options?.virtualAgentId)
+
+  const agent = wozProfiles.find((d) => d.id === step?.options?.virtualAgentId)
+
+  const agentName = () => {
+    if (!agent?.name) return 'Woz'
+
+    if (!agent.active) {
+      return `${agent.name} (inativo)`
+    }
+
+    return agent.name
+  }
 
   return (
     <Stack>
-      <Text noOfLines={0}>
-        Agente: {!agent?.name ? 'Woz' : agent.name}
-      </Text>
+      <Text noOfLines={0}>Agente: {agentName()}</Text>
+
       <OctaDivider />
+
       <Text noOfLines={0}>
         Apresenta-se como IA? {step?.options?.introduceAsIA ? 'Sim' : 'Não'}
       </Text>
+
       <OctaDivider />
+
       <Text noOfLines={0}>
-        Confirma ida para próxima ação? {step?.options?.confirmContext ? 'Sim' : 'Não'}
+        Confirma ida para próxima ação?{' '}
+        {step?.options?.confirmContext ? 'Sim' : 'Não'}
       </Text>
+
       <OctaDivider />
+
       <Text noOfLines={0}>
         Redirecionamento baseado no assunto da conversa:
       </Text>
+
       <ItemNodesList step={step} indices={indices} />
+
       <OctaDivider />
-      <Text fontSize={"13px"} align={"center"} color={"blue"}>
+      <Text fontSize={'13px'} align={'center'} color={'blue'}>
         <span>Saiba mais...</span>
       </Text>
     </Stack>


### PR DESCRIPTION
# Description

Mostrando perfis inativos no select de perfis do woz

<kbd>![image](https://github.com/user-attachments/assets/12de7e38-af29-4368-9503-c90d28b6b79a)</kbd>

Fixes # (issue)
Relates to # (pull request number)

## Type of change

Consult [this](https://www.notion.so/octatech/Conven-o-de-Commits-6e9ddde2c4e44cdc9c50e7a0ef42b18c#b34b7041baa24ed28d422cb20de9e744) readme and set the correspondent label(s) on PR.

## Breaking change

If your fix/feature changed the current expected behavior or the communication with it, explain.

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~New and existing unit tests pass locally with my changes~~
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~
- [ ] ~~I have updated [Mapeamento](https://docs.google.com/spreadsheets/d/1i6yP07og51aktbzKs-YVXlsvB1gCGHKPxn06HspTNto) with any new dependency~~
