### PR TITLE
fix: Removed test request select limit when creating a bot

### DIFF
--- a/apps/builder/components/shared/SearchableDropdown.tsx
+++ b/apps/builder/components/shared/SearchableDropdown.tsx
@@ -1,17 +1,17 @@
 import {
+  Button,
+  Flex,
+  HStack,
+  Input,
+  InputProps,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   useDisclosure,
   useOutsideClick,
-  Flex,
-  Popover,
-  PopoverTrigger,
-  Input,
-  PopoverContent,
-  Button,
-  InputProps,
-  HStack,
 } from '@chakra-ui/react'
 import { Variable } from 'models'
-import { useState, useRef, useEffect, ChangeEvent } from 'react'
+import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 import { isEmpty } from 'utils'
 import { VariablesButton } from './buttons/VariablesButton'
@@ -37,7 +37,7 @@ export const SearchableDropdown = ({
   const [inputValue, setInputValue] = useState(selectedItem ?? '')
   const debounced = useDebouncedCallback(
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    onValueChange ? onValueChange : () => {},
+    onValueChange ? onValueChange : () => { },
     isEmpty(process.env.NEXT_PUBLIC_E2E_TEST) ? debounceTimeout : 0
   )
   const [filteredItems, setFilteredItems] = useState([
@@ -45,7 +45,7 @@ export const SearchableDropdown = ({
       .filter((item) =>
         item.toLowerCase().includes((selectedItem ?? '').toLowerCase())
       )
-      .slice(0, 50),
+    // .slice(0, 50),
   ])
   const dropdownRef = useRef(null)
   const inputRef = useRef<HTMLInputElement>(null)


### PR DESCRIPTION
# Description
The modification was made to fix the limitation of options returned within the SearchableDropdown, which did not capture all the objects returned from the respective query.

## Type of change
[x] Fix


# How has this been tested?
The test was conducted with requests to different endpoints, which returned a large object to validate whether it would still limit the number of items displayed in the select.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated [Mapeamento](https://docs.google.com/spreadsheets/d/1i6yP07og51aktbzKs-YVXlsvB1gCGHKPxn06HspTNto) with any new dependency
