### PR TITLE
fix: add 23hrs and 59min on office hours select

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/OfficeHoursBody/OfficeHoursIntervalTimer.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/OfficeHoursBody/OfficeHoursIntervalTimer.tsx
@@ -32,6 +32,11 @@ export const OfficeHoursIntervalTimer = (
         return { key: control++, label, value: label + ':00' }
       }),
     ]
+
+    if (i === 23) {
+      const lastMinuteOfDay = getNumberWithTwoDigits(i) + ':' + getNumberWithTwoDigits(59)
+      hoursByQuarter.push({ key: control++, label: lastMinuteOfDay, value: lastMinuteOfDay + ':00' })
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
# Descrição

Adicionando opção no select de office hours para 23 e 59 no bot v2, pois a última opção era 23 e 45

Incidente ou Problema: [ticket](https://beta.octadesk.com/ticket/edit/188803)

# Testes

- Abrir um bot do tipo V2
- Adicionar uma etapa de definir horário de atendimento
- Editar o horário de atendimento como mesmo horário todos os dias e adicionar o horário de encerramento como 23 e 59
- Fazer a mesma edição com mesmo horário desativado

# Checklist:

- [x] O código segue os padrões do projeto;
- [x] Todos os testes passaram;
- [x] A branch está mesclada com development e staging
- [x] Atualizei o README/Base de Conhecimento caso tenha alguma alteração ou adição na regra de negócio
- [x] Atualizei o Mapeamento caso tenha alguma nova dependência de serviço ou tecnologia
