### PR TITLE
fix: fixed specialdate undefined

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/OfficeHoursBody/SpecialDate.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/OfficeHoursBody/SpecialDate.tsx
@@ -6,7 +6,7 @@ import {
   Options,
   SpecialDateContainer,
 } from './OfficeHoursBody.style'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Interval, SpecialDate } from './OfficeHoursBody'
 import { TableListItemProps } from 'components/shared/TableListOcta'
 import { Box, FormControl, HStack, Stack, Text, Button } from '@chakra-ui/react'
@@ -47,6 +47,10 @@ export const SpecialDateComponent = (
 
     props.onItemChange({ ...props.item, hours: values })
   }
+
+  useEffect(() => {
+    changeDate(currentDate);
+  },[])
 
   const changeDate = (date: Date) => {
     setCurrentDate(date)


### PR DESCRIPTION
# Descrição

Adicionamos um UseEffect para quando o componente ser renderizado o changeDate setar a data padrão no componente, que no caso é a data atual.

Incidente ou Problema #[ (ID do jira, ticket ou servicenow)](https://lwp.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3D33c893e49749a69034abb8b0f053af56%26sysparm_record_target%3Dincident%26sysparm_record_row%3D1%26sysparm_record_rows%3D1%26sysparm_record_list%3Dactive%253Dtrue%255Eassignment_group%253Djavascript%253AgetMyGroups%2528%2529%255Enumber%253DINC8362625%255EORDERBYnumber)


# Testes
![image](https://github.com/user-attachments/assets/edfc285e-be5b-4a25-a904-7db9de0fe4c0)



- Incluimos um horario especial sem clicar no componente de date-pick e salvamos a data.


# Checklist:

- [x] O código segue os padrões do projeto;
- [x] Todos os testes passaram;
- [x] A branch está mesclada com development e staging
- [ ] Atualizei o README/Base de Conhecimento caso tenha alguma alteração ou adição na regra de negócio
- [ ] Atualizei o Mapeamento caso tenha alguma nova dependência de serviço ou tecnologia
