### PR TITLE
fix: find survey variables by id instead of variableId

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WebhookSettings/WebhookSettings.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WebhookSettings/WebhookSettings.tsx
@@ -365,7 +365,10 @@ export const WebhookSettings = React.memo(function WebhookSettings({
     }
 
     variablesForTest.forEach((testVariable) => {
-      const variable = variables.find((v) => v.id === testVariable.variableId)
+      const variable = variables.find(
+        (v) => v.id === testVariable.variableId || v.id === testVariable.id
+      )
+
       if (!variable) return
 
       const light: VariableLight = {


### PR DESCRIPTION
Agora busca as variaveis tanto pelo variableId quanto pelo id