### PR TITLE
fix: when variableid is not found in variables the field has to show ...

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WithVariableContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WithVariableContent.tsx
@@ -23,7 +23,7 @@ export const WithVariableContent = ({ variableId, property }: Props) => {
 
       if (!variable && property?.token) createChatField(property, variableId)
 
-      const variableName = variable?.token || property?.token || '...'
+      const variableName = variable?.token  || '...'
       setVariableName(variableName)
     }
     return () => {


### PR DESCRIPTION
# Descrição

Removemos o uso do property.token que causava o problema de mesmo quando o id era indefinido o field renderizava o nome da variavel

Incidente ou Problema # [(issue)](https://app.octadesk.com/ticket/edit/193165)


# Testes

![image](https://github.com/user-attachments/assets/479f4943-d24b-4f96-bb39-d6d63b80487e)


- Forcamos o id undefined ou string vazia e validamos o comportamento do field

# Checklist:

- [x] O código segue os padrões do projeto;
- [x] Todos os testes passaram;
- [x] A branch está mesclada com development e staging
- [ ] Atualizei o README/Base de Conhecimento caso tenha alguma alteração ou adição na regra de negócio
- [ ] Atualizei o Mapeamento caso tenha alguma nova dependência de serviço ou tecnologia
