### PR TITLE
fix: ensure setVariables correctly updates state in context

### DIFF
--- a/apps/builder/contexts/TypebotContext/actions/variables.ts
+++ b/apps/builder/contexts/TypebotContext/actions/variables.ts
@@ -27,7 +27,10 @@ export const variablesAction = (setTypebot: SetTypebot): VariablesActions => ({
     setTypebot((typebot) =>
       produce(typebot, (newTypebot) => {
         if (!newTypebot) return
-        setVariableDraft(typebot, variables)   
+        const newVariables = variables.filter(
+          (v) => !typebot.variables.some((existing) => existing.token === v.token)
+        )
+        typebot.variables.push(...newVariables)
       })
     ),
   updateVariable: (
@@ -59,14 +62,4 @@ export const deleteVariableDraft = (
   if (!typebot) return
   const index = typebot.variables.findIndex((v) => v.id === variableId)
   typebot.variables.splice(index, 1)
-}
-
-export const setVariableDraft = (
-  typebot: WritableDraft<Typebot>,
-  variables: Array<Variable>
-) => {
-  const newVariables = variables.filter(
-    (v) => !typebot.variables.some((existing) => existing.token === v.token)
-  )
-  typebot.variables.push(...newVariables)
 }

--- a/apps/builder/contexts/TypebotContext/actions/variables.ts
+++ b/apps/builder/contexts/TypebotContext/actions/variables.ts
@@ -25,9 +25,9 @@ export const variablesAction = (setTypebot: SetTypebot): VariablesActions => ({
     ),
   setVariables: (variables: Array<Variable>) =>
     setTypebot((typebot) =>
-      produce(typebot, (typebot) => {
-        if (!typebot) return
-        typebot.variables = variables
+      produce(typebot, (newTypebot) => {
+        if (!newTypebot) return
+        setVariableDraft(typebot, variables)   
       })
     ),
   updateVariable: (
@@ -59,4 +59,14 @@ export const deleteVariableDraft = (
   if (!typebot) return
   const index = typebot.variables.findIndex((v) => v.id === variableId)
   typebot.variables.splice(index, 1)
+}
+
+export const setVariableDraft = (
+  typebot: WritableDraft<Typebot>,
+  variables: Array<Variable>
+) => {
+  const newVariables = variables.filter(
+    (v) => !typebot.variables.some((existing) => existing.token === v.token)
+  )
+  typebot.variables.push(...newVariables)
 }


### PR DESCRIPTION
# Descrição

Durante a análise, foi identificado que durante o processo de atualização o sistema não estava alterando o objeto base e dessa forma o react não fazia a renderização do componente novamente adicionando os campos default. Essa alteração só era refletida quando ocorria alguma alteração no objeto do contexto seja carregando a tela novamente ou realizando alguma alteração em qualquer outro campo. Foi então realizado ajuste no método para ao invés de alterar a cópia do objeto, realizar a modificação no objeto original e dessa forma o sistema passou a reconhecer a alteração e exibir o objeto corretamente.

Incidente ou Problema # ([KSC-334](https://octadesk1614602251.atlassian.net/browse/KSC-334))

# Testes

Com as alterações em QA, foi realizado a alteração de um bot versão V1 para versão V2 e verificado que todas as variáveis estavam presentes.

<img width="485" height="535" alt="image" src="https://github.com/user-attachments/assets/27e96d6d-24f5-45b9-adfa-771bf6ae61e7" />

# Checklist:

- [X] O código segue os padrões do projeto;
- [X] Todos os testes passaram;
- [X] A branch está mesclada com development e staging
- [ ] Atualizei o README/Base de Conhecimento caso tenha alguma alteração ou adição na regra de negócio
- [ ] Atualizei o Mapeamento caso tenha alguma nova dependência de serviço ou tecnologia


[KSC-334]: https://octadesk1614602251.atlassian.net/browse/KSC-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ