### PR TITLE
fix: show message on checklist without components

### DIFF
--- a/apps/builder/components/editor/todoList/index.tsx
+++ b/apps/builder/components/editor/todoList/index.tsx
@@ -36,10 +36,11 @@ export const ToDoList = () => {
   const groupsWithoutConnection = () =>
     typebot?.blocks?.filter((block) => !block.hasConnection)
 
+  const hasMoreThanOneBlock = () => (typebot?.blocks ? typebot.blocks.length : 0) > 1;
   const hasGroupsWithoutConnection = () => !!groupsWithoutConnection()?.length
 
   const showEmptyPendenciesList = () =>
-    !hasGroupsWithoutConnection() && emptyFields.length < 1
+    !hasGroupsWithoutConnection() && hasMoreThanOneBlock() && emptyFields.length < 1
 
   const groupsWithEmptyFields = () => {
     if (emptyFields.length === 0) return []
@@ -232,6 +233,17 @@ export const ToDoList = () => {
                   ))}
                 </>
               )}
+                {!hasMoreThanOneBlock() && (
+                  <Text
+                    color="black"
+                    fontSize="14px"
+                    textAlign="center"
+                    fontFamily="Poppins"
+                    marginTop="24px"
+                  >
+                    Seu bot Não possui blocos.
+                  </Text>
+                )}
             </Flex>
           </Flex>
         )}

--- a/apps/builder/pages/typebots/[typebotId]/edit.tsx
+++ b/apps/builder/pages/typebots/[typebotId]/edit.tsx
@@ -46,7 +46,7 @@ function TypebotEditPage() {
     window.parent.postMessage(
       {
         name: 'hasMoreThanOneBlock',
-        hasGroupsWithoutConnection,
+        hasMoreThanOneBlock,
         value: hasMoreThanOneBlock,
       },
       '*'

--- a/apps/builder/pages/typebots/[typebotId]/edit.tsx
+++ b/apps/builder/pages/typebots/[typebotId]/edit.tsx
@@ -41,7 +41,16 @@ function TypebotEditPage() {
     )
 
     const hasGroupsWithoutConnection = !!groupsWithoutConnection?.length
+    const hasMoreThanOneBlock = (typebot?.blocks ? typebot.blocks.length : 0) > 1;
 
+    window.parent.postMessage(
+      {
+        name: 'hasMoreThanOneBlock',
+        hasGroupsWithoutConnection,
+        value: hasMoreThanOneBlock,
+      },
+      '*'
+    )
     window.parent.postMessage(
       {
         name: 'groupsWithoutConnection',


### PR DESCRIPTION
# Descrição

Foi realizado o ajuste para exibir um checklist ao deixar o bot sem componentes

Incidente ou Problema # ([KSC-339](https://octadesk1614602251.atlassian.net/browse/KSC-339))

# Testes

Foi testado em QA e no local

<img width="1918" height="962" alt="print-1" src="https://github.com/user-attachments/assets/f02960c1-2d4e-405e-9e9c-621119798c7b" />
<img width="1916" height="972" alt="print-2" src="https://github.com/user-attachments/assets/af404354-324b-489b-a046-01d4eb64b041" />
<img width="1918" height="957" alt="print-3" src="https://github.com/user-attachments/assets/d8a8daf6-1229-486e-ac78-860741147f2d" />

# Checklist:

- [x] O código segue os padrões do projeto;
- [x] Todos os testes passaram;
- [x] A branch está mesclada com development e staging
- [ ] Atualizei o README/Base de Conhecimento caso tenha alguma alteração ou adição na regra de negócio
- [ ] Atualizei o Mapeamento caso tenha alguma nova dependência de serviço ou tecnologia


[KSC-339]: https://octadesk1614602251.atlassian.net/browse/KSC-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ