### PR TITLE
fix: ksc 339 fix checklist on save without components

### DIFF
--- a/apps/builder/components/editor/todoList/index.tsx
+++ b/apps/builder/components/editor/todoList/index.tsx
@@ -36,10 +36,11 @@ export const ToDoList = () => {
   const groupsWithoutConnection = () =>
     typebot?.blocks?.filter((block) => !block.hasConnection)
 
+  const hasMoreThanOneBlock = () => (typebot?.blocks ? typebot.blocks.length : 0) > 1;
   const hasGroupsWithoutConnection = () => !!groupsWithoutConnection()?.length
 
   const showEmptyPendenciesList = () =>
-    !hasGroupsWithoutConnection() && emptyFields.length < 1
+    !hasGroupsWithoutConnection() && hasMoreThanOneBlock() && emptyFields.length < 1
 
   const groupsWithEmptyFields = () => {
     if (emptyFields.length === 0) return []
@@ -232,6 +233,17 @@ export const ToDoList = () => {
                   ))}
                 </>
               )}
+                {!hasMoreThanOneBlock() && (
+                  <Text
+                    color="black"
+                    fontSize="14px"
+                    textAlign="center"
+                    fontFamily="Poppins"
+                    marginTop="24px"
+                  >
+                    Seu bot Não possui blocos.
+                  </Text>
+                )}
             </Flex>
           </Flex>
         )}

--- a/apps/builder/pages/typebots/[typebotId]/edit.tsx
+++ b/apps/builder/pages/typebots/[typebotId]/edit.tsx
@@ -46,7 +46,7 @@ function TypebotEditPage() {
     window.parent.postMessage(
       {
         name: 'hasMoreThanOneBlock',
-        hasGroupsWithoutConnection,
+        hasMoreThanOneBlock,
         value: hasMoreThanOneBlock,
       },
       '*'

--- a/apps/builder/pages/typebots/[typebotId]/edit.tsx
+++ b/apps/builder/pages/typebots/[typebotId]/edit.tsx
@@ -41,7 +41,16 @@ function TypebotEditPage() {
     )
 
     const hasGroupsWithoutConnection = !!groupsWithoutConnection?.length
+    const hasMoreThanOneBlock = (typebot?.blocks ? typebot.blocks.length : 0) > 1;
 
+    window.parent.postMessage(
+      {
+        name: 'hasMoreThanOneBlock',
+        hasGroupsWithoutConnection,
+        value: hasMoreThanOneBlock,
+      },
+      '*'
+    )
     window.parent.postMessage(
       {
         name: 'groupsWithoutConnection',

--- a/build/codefresh.yaml
+++ b/build/codefresh.yaml
@@ -176,6 +176,13 @@ steps:
           yq w -i "${APPLICATION_NAME}-${{SCOPE}}.yaml" ${{YQ_IMAGE_TAG_FORMAT}} ${TAG}
         fi
 
+        if [[ "${VERSION}" == "${{DEVELOPMENT_FLAG}}" ]]; then
+          cd "${CF_VOLUME_PATH}/${{GIT_IAC_REPOSITORY}}/environments/octa-dev-cloudstack/values"
+          find . -name "${REPO_NAME_PATH}" | while read line; do
+              yq w -i $line "${YQ_IMAGE_TAG_FORMAT}" ${TAG} --anchorName=imageTag;
+          done
+        fi
+
         yq w -i "${CHART_ROOT_PATH}/${{VERSIONS_PATH}}" "${APPLICATION_NAME}-${{SCOPE}}.${VERSION}" "${TAG}"
     when:
       condition:

--- a/build/codefresh.yaml
+++ b/build/codefresh.yaml
@@ -178,9 +178,7 @@ steps:
 
         if [[ "${VERSION}" == "${{DEVELOPMENT_FLAG}}" ]]; then
           cd "${CF_VOLUME_PATH}/${{GIT_IAC_REPOSITORY}}/environments/octa-dev-cloudstack/values"
-          find . -name "${REPO_NAME_PATH}" | while read line; do
-              yq w -i $line "${YQ_IMAGE_TAG_FORMAT}" ${TAG} --anchorName=imageTag;
-          done
+          yq w -i "${APPLICATION_NAME}-${{SCOPE}}.yaml" ${{YQ_IMAGE_TAG_FORMAT}} ${TAG}
         fi
 
         yq w -i "${CHART_ROOT_PATH}/${{VERSIONS_PATH}}" "${APPLICATION_NAME}-${{SCOPE}}.${VERSION}" "${TAG}"


### PR DESCRIPTION
# Descrição

Descreva quais mudanças foram realizadas, como alterações e adições na regra de negócio, novos arquivos e por que.

Incidente ou Problema # (ID do jira, ticket ou servicenow)
Relacionado # (Fix de algum PR?)

# Testes

- Descreva quais novos testes foram desenvolvidos no código
- Descreva como foi realizado os testes da mudança.

# Checklist:

- [ ] O código segue os padrões do projeto;
- [ ] Todos os testes passaram;
- [ ] A branch está mesclada com development e staging
- [ ] Atualizei o README/Base de Conhecimento caso tenha alguma alteração ou adição na regra de negócio
- [ ] Atualizei o Mapeamento caso tenha alguma nova dependência de serviço ou tecnologia

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds hasMoreThanOneBlock logic and UI/message updates in the editor, plus Codefresh step to update the dev env image tag on development builds.
> 
> - **Editor (builder)**:
>   - **ToDo List (`apps/builder/components/editor/todoList/index.tsx`)**:
>     - Add `hasMoreThanOneBlock` and require it for showing "no pendências" state.
>     - Show centered message when there are no blocks: `Seu bot Não possui blocos.`
>   - **Edit Page (`apps/builder/pages/typebots/[typebotId]/edit.tsx`)**:
>     - Compute `hasMoreThanOneBlock` and post `window.parent` message `{ name: 'hasMoreThanOneBlock', value }`.
>     - Continue posting `groupsWithoutConnection` updates.
> - **CI/CD (`build/codefresh.yaml`)**:
>   - On development builds (`VERSION == DEVELOPMENT_FLAG`), also update image tag in `environments/octa-dev-cloudstack/values/${APPLICATION_NAME}-${SCOPE}.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85a9a4888fb42496dd566eccb949cf5f2ba9f1fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->