### PR TITLE
fix: prevent edge oscillation loop and fix undo stack on graph connections

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/AssignToTeam/AssignToTeamContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/AssignToTeam/AssignToTeamContent.tsx
@@ -25,19 +25,19 @@ export const AssignToTeamContent = ({
 
   React.useEffect(() => {
     if (
-      !verifyFeatureToggle('customer-recontact') 
+      !verifyFeatureToggle('customer-recontact')
       || typeof onUpdateStep !== 'function'
     ) return
-    
+
     const showChatReturnOption = hasAnyChatReturnInItsTree(typebot, step.blockId)
-    let options = {} as AssignToTeamOptions
-    if (!showChatReturnOption && step.options?.assignType === '@CHAT-RETURN') {
-      options.assignTo = ''
-      options.assignType = ''
-    }
-    
+    const needsAssignClear = !showChatReturnOption && step.options?.assignType === '@CHAT-RETURN'
+
+    if (step.options?.showChatReturnOption === showChatReturnOption && !needsAssignClear) return
+
     onUpdateStep({
-      ...step.options, ... options, showChatReturnOption
+      ...step.options,
+      ...(needsAssignClear ? { assignTo: '', assignType: '' } : {}),
+      showChatReturnOption,
     })
   }, [typebot?.edges])
 

--- a/apps/builder/contexts/TypebotContext/TypebotContext.tsx
+++ b/apps/builder/contexts/TypebotContext/TypebotContext.tsx
@@ -212,7 +212,7 @@ export const TypebotContext = ({
       new Date(typebot.updatedAt) >
       new Date(currentTypebotRef.current.updatedAt)
     ) {
-      setLocalTypebot({ ...parsedTypebot })
+      setLocalTypebot({ ...parsedTypebot }, { skipHistory: true })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [typebot])
@@ -226,8 +226,8 @@ export const TypebotContext = ({
 
     if (localTypebot?.hasPendingIssues === hasPendingIssues) return
 
-    updateLocalTypebot({ hasPendingIssues })
-  }, [localTypebot?.edges, emptyFields])
+    setLocalTypebot({ ...localTypebot, hasPendingIssues }, { skipHistory: true })
+  }, [localTypebot, emptyFields, setLocalTypebot])
 
   const saveTypebot = async (
     personaName?: string,
@@ -258,11 +258,14 @@ export const TypebotContext = ({
     }
 
     if (!options?.disableMutation)
-      mutate({
-        typebot: typebotToSave,
-        publishedTypebot,
-        webhooks: webhooks ?? [],
-      })
+      mutate(
+        {
+          typebot: typebotToSave,
+          publishedTypebot,
+          webhooks: webhooks ?? [],
+        },
+        { revalidate: false }
+      )
     window.removeEventListener('beforeunload', preventUserFromRefreshing)
 
     return { saved: true, updateAt: typebotToSave.updatedAt }
@@ -276,11 +279,14 @@ export const TypebotContext = ({
     )
     setIsPublishing(false)
     if (error) return toast({ title: error.name, description: error.message })
-    mutate({
-      typebot: currentTypebotRef.current as Typebot,
-      publishedTypebot: newPublishedTypebot,
-      webhooks: webhooks ?? [],
-    })
+    mutate(
+      {
+        typebot: currentTypebotRef.current as Typebot,
+        publishedTypebot: newPublishedTypebot,
+        webhooks: webhooks ?? [],
+      },
+      { revalidate: false }
+    )
   }
 
   useEffect(() => {
@@ -749,6 +755,7 @@ export const useFetchedTypebot = ({
     Error
   >(`/getTypebot-${typebotId}`, fetcher, {
     dedupingInterval: 60000 * 60 * 24,
+    revalidateOnFocus: false,
   })
 
   if (error) onError(error)

--- a/apps/builder/contexts/TypebotContext/TypebotContext.tsx
+++ b/apps/builder/contexts/TypebotContext/TypebotContext.tsx
@@ -218,16 +218,21 @@ export const TypebotContext = ({
   }, [typebot])
 
   useEffect(() => {
-    if (!localTypebot) return
-    const hasBlocksWithoutConection = localTypebot.blocks.some(
+    const currentTypebot = currentTypebotRef.current
+
+    if (!currentTypebot) return
+
+    const hasBlocksWithoutConection = currentTypebot.blocks.some(
       (b) => !b.hasConnection
     )
+
     const hasPendingIssues = hasBlocksWithoutConection || emptyFields.length > 0
 
-    if (localTypebot?.hasPendingIssues === hasPendingIssues) return
+    if (currentTypebot.hasPendingIssues === hasPendingIssues) return
 
-    setLocalTypebot({ ...localTypebot, hasPendingIssues }, { skipHistory: true })
-  }, [localTypebot, emptyFields, setLocalTypebot])
+    setLocalTypebot({ ...currentTypebot, hasPendingIssues }, { skipHistory: true })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localTypebot?.edges, emptyFields])
 
   const saveTypebot = async (
     personaName?: string,

--- a/apps/builder/services/utils/useUndo.ts
+++ b/apps/builder/services/utils/useUndo.ts
@@ -156,8 +156,11 @@ const useUndo = <T>(initialPresent: T): [State<T>, Actions<T>] => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const newUpdatedAt = updateDate ? new Date() : (updatedTypebot as any)?.updatedAt
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      presentRef.current = { ...(updatedTypebot as any), updatedAt: newUpdatedAt } as T
+      presentRef.current = updatedTypebot != null
+        ? ({ ...(updatedTypebot as any), updatedAt: newUpdatedAt } as T)
+        : (updatedTypebot as T)
 
       dispatch({
         type: ActionType.Set,

--- a/apps/builder/services/utils/useUndo.ts
+++ b/apps/builder/services/utils/useUndo.ts
@@ -15,7 +15,7 @@ enum ActionType {
 export interface Actions<T> {
   set: (
     newPresent: T | ((current: T) => T),
-    options?: { updateDate: boolean }
+    options?: { updateDate?: boolean; skipHistory?: boolean }
   ) => void
   undo: () => void
   redo: () => void
@@ -29,6 +29,7 @@ interface Action<T> {
   type: ActionType
   newPresent?: T
   updateDate?: boolean
+  skipHistory?: boolean
 }
 
 export interface State<T> {
@@ -77,7 +78,7 @@ const reducer = <T>(state: State<T>, action: Action<T>) => {
     }
 
     case ActionType.Set: {
-      const { newPresent, updateDate } = action
+      const { newPresent, updateDate, skipHistory } = action
       if (
         isNotDefined(newPresent) ||
         (present &&
@@ -89,14 +90,23 @@ const reducer = <T>(state: State<T>, action: Action<T>) => {
         return state
       }
 
+      const nextPresent = {
+        ...newPresent,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        updatedAt: updateDate ? new Date() : newPresent.updatedAt,
+      }
+
+      if (skipHistory) {
+        return {
+          ...state,
+          present: nextPresent,
+        }
+      }
+
       return {
         past: [...past, present].filter(isDefined),
-        present: {
-          ...newPresent,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          //@ts-ignore
-          updatedAt: updateDate ? new Date() : newPresent.updatedAt,
-        },
+        present: nextPresent,
         future: [],
       }
     }
@@ -129,21 +139,31 @@ const useUndo = <T>(initialPresent: T): [State<T>, Actions<T>] => {
   }, [canRedo])
 
   const set = useCallback(
-    (newPresent: T | ((current: T) => T), options = { updateDate: true }) => {
+    (
+      newPresent: T | ((current: T) => T),
+      options: { updateDate?: boolean; skipHistory?: boolean } = {}
+    ) => {
+      const { updateDate = true, skipHistory = false } = options
+
       const updatedTypebot =
         'id' in newPresent
           ? newPresent
           : (newPresent as (current: T) => T)(presentRef.current)
-      presentRef.current = updatedTypebot
 
       if (updatedTypebot?.blocks) {
         updatedTypebot.blocks = updateBlocksHasConnections(updatedTypebot)
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const newUpdatedAt = updateDate ? new Date() : (updatedTypebot as any)?.updatedAt
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      presentRef.current = { ...(updatedTypebot as any), updatedAt: newUpdatedAt } as T
+
       dispatch({
         type: ActionType.Set,
         newPresent: updatedTypebot,
-        updateDate: options.updateDate,
+        updateDate,
+        skipHistory,
       })
     },
     []


### PR DESCRIPTION
## Contexto

Ao tentar criar ou desfazer uma conexão entre blocos no editor de fluxo, três bugs ocorriam em conjunto:

1. Loop de atualizações de estado travando o navegador
2. Oscillação do array de edges corrompendo o estado visual
3. Primeiro "Desfazer" não desfazia a conexão e exigia dois acionamentos

## Mudanças

- **`AssignToTeamContent.tsx`**: adicionado guard para que `onUpdateStep` só seja chamado quando `showChatReturnOption` efetivamente muda.

- **`useUndo.ts`**: `presentRef.current` agora recebe o `updatedAt` correto (igual ao que o reducer vai usar), eliminando a janela de timestamp defasado. Adicionada opção `skipHistory` ao `set()`: quando `true`, atualiza o `present` sem tocar em `past` ou `future`.

- **`TypebotContext.tsx`**: `revalidateOnFocus: false` no SWR e `{ revalidate: false }` nos `mutate()` de save, impedindo refetches com dados antigos. Updates derivados (`hasPendingIssues`, sync servidor) agora usam `skipHistory: true`.
