### PR TITLE
fix: add unique keys to Box components in WhatsApp settings bodies

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WhatsAppBodies/WhatsAppButtonsListSettings/WhatsAppButtonsListSettingsBody.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WhatsAppBodies/WhatsAppButtonsListSettings/WhatsAppButtonsListSettingsBody.tsx
@@ -158,7 +158,7 @@ export const WhatsAppButtonsListSettingsBody = ({
     index: number
   ) => {
     return (
-      <Box>
+      <Box key={(message as any)?.id ?? `fallback-${index}`}>
         <FormLabel mb="0" htmlFor="placeholder" fontWeight="bold" fontSize="sm">
           Mensagem para resposta inválida - Tentativa {index + 1}
         </FormLabel>

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WhatsAppBodies/WhatsAppOptionsListSettings/WhatsAppOptionsListSettingsBody.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/WhatsAppBodies/WhatsAppOptionsListSettings/WhatsAppOptionsListSettingsBody.tsx
@@ -175,7 +175,7 @@ export const WhatsAppOptionsListSettingsBody = ({
     index: number
   ) => {
     return (
-      <Box>
+      <Box key={(message as any)?.id ?? `fallback-${index}`}>
         <FormLabel mb="0" htmlFor="placeholder" fontWeight="bold" fontSize="sm">
           Mensagem para resposta inválida - Tentativa {index + 1}
         </FormLabel>

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/TextBubbleEditor/TextBubbleEditor.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/TextBubbleEditor/TextBubbleEditor.tsx
@@ -25,6 +25,7 @@ import { VariableSearchInput } from 'components/shared/VariableSearchInput/Varia
 import { ToolBar } from './ToolBar'
 import DOMPurify from 'dompurify'
 import { textBubbleEditorConfig } from 'config/dompurify'
+import cuid from 'cuid'
 
 type TextBubbleEditorProps = {
   initialValue: TElement[]
@@ -65,7 +66,7 @@ export const TextBubbleEditor = ({
   const hasShownLimitMessage = useRef(false)
 
   const editorId = useRef(
-    `text-bubble-editor-${increment ?? ''}-${Date.now()}`
+    `text-bubble-editor-${increment ?? ''}-${cuid()}`
   ).current
 
   const editor = useMemo(() => {


### PR DESCRIPTION
# Descrição

Ao editar uma mensagem de fallback das etapas `Pergunta com lista de opções` ou `Pergunta com lista de botões` acabava editando o texto da outra etapa.

Essa mudança visa resolver esse cenário.

https://octadesk1614602251.atlassian.net/browse/CHAT-2137
