### PR TITLE
chore: run container as non-root user for GKE 1.34 compliance

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-# https://github.com/vercel/turborepo/issues/215#issuecomment-1027058056
+﻿# https://github.com/vercel/turborepo/issues/215#issuecomment-1027058056
 #FROM node:18-slim AS base
 FROM node:18-bullseye-slim AS base
 WORKDIR /app
@@ -52,8 +52,10 @@ COPY entrypoint.sh ./
 COPY ${SCOPE}-entrypoint.sh ./
 RUN chmod +x ./${SCOPE}-entrypoint.sh
 RUN chmod +x ./entrypoint.sh
+RUN chown -R node:node /app
+USER node
 ENTRYPOINT ./${SCOPE}-entrypoint.sh
 
-EXPOSE 80
-ENV PORT 80
+EXPOSE 3000
+ENV PORT 3000
 


### PR DESCRIPTION
## GKE 1.34 — Non-Root Container Compliance

A partir da versão 1.34 do GKE, containers que rodam como `root` ou fazem bind em portas < 1024 entram em crash por violação das políticas de segurança do Kubernetes.

### Alterações
- Adicionado `USER` non-root para garantir que o container não rode como root
- Ajustes de permissão via `chown` para que o usuário non-root tenha acesso aos arquivos da aplicação
- Alteração de porta onde necessário (< 1024 → ≥ 1024)

### Referência
Documentação interna: `octa-iac/docs/gke-1.34-non-root-migration.md`