### PR TITLE
feat: bot builder increase performance

### DIFF
--- a/apps/builder/assets/icons.tsx
+++ b/apps/builder/assets/icons.tsx
@@ -80,7 +80,11 @@ export const FolderPlusIcon = (props: IconProps) => (
 
 export const TextIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdChatBubbleOutline />
@@ -90,7 +94,11 @@ export const TextIcon = (props: any) => (
 
 export const WandIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdAutoFixHigh />
@@ -100,11 +108,12 @@ export const WandIcon = (props: any) => (
 
 export const AIIcon = (props: any) => (
   <svg
-    width="16"
-    height="16"
+    width="1em"
+    height="1em"
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
     <path
       d="M14 0.5H2C1.175 0.5 0.5 1.175 0.5 2V15.5L3.5 12.5H14C14.825 12.5 15.5 11.825 15.5 11V2C15.5 1.175 14.825 0.5 14 0.5ZM14 11H2.9L2 11.9V2H14V11Z"
@@ -143,11 +152,12 @@ export const AIIcon = (props: any) => (
 
 export const InterpretDataWithAIIcon = (props: any) => (
   <svg
-    width="18"
-    height="18"
+    width="1em"
+    height="1em"
     viewBox="0 0 18 18"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
     <path
       d="M4.50237 3.84379C4.48898 3.54411 4.53566 3.24478 4.63965 2.9634C4.74365 2.68203 4.90286 2.42429 5.10792 2.20534C5.31298 1.9864 5.55975 1.81067 5.83372 1.68849C6.10769 1.56631 6.40333 1.50015 6.70324 1.4939C7.00315 1.48765 7.30129 1.54143 7.58011 1.65209C7.85893 1.76274 8.11281 1.92804 8.32682 2.13825C8.54082 2.34846 8.71063 2.59934 8.82626 2.87614C8.94189 3.15294 9.001 3.45006 9.00012 3.75004V13.5M4.50237 3.84379C4.06152 3.95714 3.65224 4.16933 3.30554 4.46427C2.95884 4.75922 2.6838 5.12919 2.50125 5.54617C2.3187 5.96316 2.23344 6.41621 2.25191 6.87102C2.27038 7.32584 2.39211 7.77048 2.60787 8.17129M4.50237 3.84379C4.5172 4.20659 4.61961 4.56041 4.80087 4.87504M2.60787 8.17129C2.2285 8.47949 1.93019 8.87571 1.73887 9.32549C1.54756 9.77527 1.46903 10.265 1.51014 10.752C1.55124 11.2391 1.71073 11.7087 1.97472 12.1201C2.23871 12.5314 2.59921 12.872 3.02487 13.1123M2.60787 8.17129C2.74507 8.05954 2.89189 7.9609 3.04662 7.87504M3.02487 13.1123C2.9723 13.519 3.00367 13.9321 3.11703 14.3262C3.23039 14.7203 3.42334 15.0869 3.68396 15.4035C3.94457 15.7201 4.26732 15.9799 4.63228 16.1669C4.99724 16.3538 5.39665 16.464 5.80585 16.4905C6.21505 16.5171 6.62535 16.4595 7.01141 16.3212C7.39747 16.183 7.75109 15.9671 8.05044 15.6869C8.34978 15.4066 8.5885 15.068 8.75184 14.6918C8.91518 14.3157 8.99968 13.9101 9.00012 13.5M3.02487 13.1123C3.47507 13.3662 3.98324 13.5003 4.50012 13.5M9.00012 13.5H13.5001C13.8979 13.5 14.2795 13.6581 14.5608 13.9394C14.8421 14.2207 15.0001 14.6022 15.0001 15V15.75M6.75012 9.75004C7.37978 9.52853 7.92963 9.12529 8.33012 8.59129C8.73062 8.0573 8.96378 7.41654 9.00012 6.75004M9.00012 9.75004H12.0001M9.00012 6.00004H15.0001M12.0001 6.00004V3.75004C12.0001 3.35221 12.1582 2.97068 12.4395 2.68938C12.7208 2.40807 13.1023 2.25004 13.5001 2.25004M12.3751 9.75004C12.3751 9.95714 12.2072 10.125 12.0001 10.125C11.793 10.125 11.6251 9.95714 11.6251 9.75004C11.6251 9.54293 11.793 9.37504 12.0001 9.37504C12.2072 9.37504 12.3751 9.54293 12.3751 9.75004ZM13.8751 2.25004C13.8751 2.45714 13.7072 2.62504 13.5001 2.62504C13.293 2.62504 13.1251 2.45714 13.1251 2.25004C13.1251 2.04293 13.293 1.87504 13.5001 1.87504C13.7072 1.87504 13.8751 2.04293 13.8751 2.25004ZM15.3751 15.75C15.3751 15.9571 15.2072 16.125 15.0001 16.125C14.793 16.125 14.6251 15.9571 14.6251 15.75C14.6251 15.5429 14.793 15.375 15.0001 15.375C15.2072 15.375 15.3751 15.5429 15.3751 15.75ZM15.3751 6.00004C15.3751 6.20714 15.2072 6.37504 15.0001 6.37504C14.793 6.37504 14.6251 6.20714 14.6251 6.00004C14.6251 5.79293 14.793 5.62504 15.0001 5.62504C15.2072 5.62504 15.3751 5.79293 15.3751 6.00004Z"
@@ -174,7 +184,11 @@ export const InterpretDataWithAIIcon = (props: any) => (
 
 export const PlugConnectIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <TbPlugConnected />
@@ -184,11 +198,12 @@ export const PlugConnectIcon = (props: any) => (
 
 export const PlugConnectIconGradient = (props: any) => (
   <svg
-    width="18"
-    height="18"
+    width="1em"
+    height="1em"
     viewBox="0 0 18 18"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
     <g clipPath="url(#clip0_872_5213)">
       <path
@@ -209,7 +224,11 @@ export const PlugConnectIconGradient = (props: any) => (
 
 export const AskNameIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdOutlineBadge />
@@ -275,7 +294,11 @@ export const UploadFileIcon = (props: any) => (
 
 export const CalendarIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdCalendarMonth />
@@ -413,7 +436,11 @@ export const PlayIcon = (props: IconProps) => (
 
 export const LayoutIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdInsertDriveFile />
@@ -472,7 +499,11 @@ export const NumberIcon = (props: any) => (
 
 export const EmailIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdEmail />
@@ -482,7 +513,11 @@ export const EmailIcon = (props: any) => (
 
 export const ContactCardIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdOutlinePermIdentity />
@@ -492,7 +527,11 @@ export const ContactCardIcon = (props: any) => (
 
 export const PhoneIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdPhone />
@@ -512,7 +551,11 @@ export const CheckSquareIcon = (props: any) => (
 
 export const WavingHandIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdWavingHand />
@@ -522,7 +565,11 @@ export const WavingHandIcon = (props: any) => (
 
 export const AssignToIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdSwapHoriz />
@@ -532,7 +579,11 @@ export const AssignToIcon = (props: any) => (
 
 export const PreReserveIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdLock />
@@ -542,7 +593,11 @@ export const PreReserveIcon = (props: any) => (
 
 export const ConversationTagIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdSell />
@@ -586,7 +641,11 @@ export const RadioIcon = (props: any) => (
 
 export const FilterIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdFilterAlt />
@@ -620,7 +679,11 @@ export const ExternalLinkIcon = (props: IconProps) => (
 
 export const FilmIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdVideoLibrary />
@@ -818,7 +881,11 @@ export const OutlineInformationIcon = (props: any) => (
 
 export const QuestionIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdHelp />
@@ -828,7 +895,11 @@ export const QuestionIcon = (props: any) => (
 
 export const CallBotIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdOutlineRouter />
@@ -838,7 +909,11 @@ export const CallBotIcon = (props: any) => (
 
 export const CommerceIcon = (props: any) => (
   <IconContext.Provider
-    value={{ color: props.color, className: 'global-class-name' }}
+    value={{
+      color: props.color,
+      className: 'global-class-name',
+      size: props.fontSize,
+    }}
   >
     <div>
       <MaterialDesign.MdStore />
@@ -857,11 +932,12 @@ export const WebhookIcon = (props: any) => (
 )
 export const ExternalEventIcon = (props: any) => (
   <svg
-    width="16"
-    height="16"
+    width="1em"
+    height="1em"
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    {...props}
   >
     <path
       d="M6.4 10.8H11.104C11.32 10.552 11.64 10.4 12 10.4C12.664 10.4 13.2 10.936 13.2 11.6C13.2 12.264 12.664 12.8 12 12.8C11.648 12.8 11.328 12.648 11.104 12.4H7.92C7.552 14.224 5.936 15.6 4 15.6C1.792 15.6 0 13.808 0 11.6C0 9.66399 1.376 8.04799 3.2 7.67999V9.33599C2.272 9.66399 1.6 10.56 1.6 11.6C1.6 12.92 2.68 14 4 14C5.32 14 6.4 12.92 6.4 11.6V10.8ZM8.4 1.99999C9.72 1.99999 10.8 3.07999 10.8 4.39999H12.4C12.4 2.19199 10.608 0.399994 8.4 0.399994C6.192 0.399994 4.4 2.19199 4.4 4.39999C4.4 5.54399 4.88 6.56799 5.64 7.29599L3.76 10.416C3.216 10.528 2.8 11.016 2.8 11.6C2.8 12.264 3.336 12.8 4 12.8C4.664 12.8 5.2 12.264 5.2 11.6C5.2 11.472 5.184 11.352 5.144 11.24L7.848 6.73599C6.792 6.48799 6 5.53599 6 4.39999C6 3.07999 7.08 1.99999 8.4 1.99999ZM12 9.19999C11.488 9.19999 11.016 9.35999 10.624 9.63199L8.184 5.57599C7.624 5.47999 7.2 4.99199 7.2 4.39999C7.2 3.73599 7.736 3.19999 8.4 3.19999C9.064 3.19999 9.6 3.73599 9.6 4.39999C9.6 4.51999 9.584 4.63199 9.552 4.74399L11.304 7.66399C11.528 7.62399 11.76 7.59999 12 7.59999C14.208 7.59999 16 9.39199 16 11.6C16 13.808 14.208 15.6 12 15.6C10.52 15.6 9.224 14.792 8.536 13.6H10.672C11.056 13.856 11.512 14 12 14C13.32 14 14.4 12.92 14.4 11.6C14.4 10.28 13.32 9.19999 12 9.19999Z"
@@ -890,8 +966,8 @@ export const ErrorIcon = (props: any) => (
 
 export const ReturnArrow = ({ color, ...props }: any) => (
   <svg
-    width="16"
-    height="16"
+    width="1em"
+    height="1em"
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/apps/builder/components/editor/BoardMenuButtonSearch.tsx
+++ b/apps/builder/components/editor/BoardMenuButtonSearch.tsx
@@ -39,14 +39,11 @@ export const BoardMenuButtonSearch = (props: BoxProps) => {
   const [searchValue, setSearchValue] = useState('')
   const [debouncedValue] = useDebounce(searchValue, 300)
 
-  // Limpa a busca ao fechar — disparado por clique fora, Esc ou seleção.
   const handleClose = () => {
     setSearchValue('')
     onClose()
   }
 
-  // O painel flutua no centro-superior da tela, mas continua sendo um
-  // descendente DOM do container — então clicar nele não conta como "fora".
   useOutsideClick({
     ref: containerRef,
     handler: handleClose,

--- a/apps/builder/components/editor/BoardMenuButtonSearch.tsx
+++ b/apps/builder/components/editor/BoardMenuButtonSearch.tsx
@@ -1,0 +1,171 @@
+import {
+  Box,
+  BoxProps,
+  Button,
+  Flex,
+  IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Text,
+  Tooltip,
+  useDisclosure,
+  useOutsideClick,
+} from '@chakra-ui/react'
+import { MdSearch } from 'react-icons/md'
+import {
+  ChangeEvent,
+  KeyboardEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { useDebounce } from 'use-debounce'
+import { useGetTypebot } from 'contexts/TypebotContext'
+import { useGraph } from 'contexts/GraphContext'
+import { useGraphFocus } from 'hooks/useGraphFocus'
+
+const MAX_RESULTS = 50
+
+export const BoardMenuButtonSearch = (props: BoxProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const getTypebot = useGetTypebot()
+  const { setFocusedBlockId } = useGraph()
+  const { focusOnCoordinates } = useGraphFocus()
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [searchValue, setSearchValue] = useState('')
+  const [debouncedValue] = useDebounce(searchValue, 300)
+
+  // Limpa a busca ao fechar — disparado por clique fora, Esc ou seleção.
+  const handleClose = () => {
+    setSearchValue('')
+    onClose()
+  }
+
+  // O painel flutua no centro-superior da tela, mas continua sendo um
+  // descendente DOM do container — então clicar nele não conta como "fora".
+  useOutsideClick({
+    ref: containerRef,
+    handler: handleClose,
+    enabled: isOpen,
+  })
+
+  useEffect(() => {
+    if (isOpen) inputRef.current?.focus()
+  }, [isOpen])
+
+  const results = useMemo(() => {
+    const query = debouncedValue.trim().toLowerCase()
+    if (!query) return []
+    const blocks = getTypebot()?.blocks ?? []
+    return blocks
+      .filter((block) => block.title?.toLowerCase().includes(query))
+      .slice(0, MAX_RESULTS)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedValue])
+
+  const handleToggle = () => {
+    if (isOpen) handleClose()
+    else onOpen()
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') handleClose()
+  }
+
+  const handleResultClick = (blockId: string, x: number, y: number) => () => {
+    focusOnCoordinates({ x, y })
+    setFocusedBlockId(blockId)
+    handleClose()
+  }
+
+  const hasQuery = debouncedValue.trim().length > 0
+
+  return (
+    <Box ref={containerRef} w="fit-content" {...props}>
+      <Tooltip label="Pesquisar bloco">
+        <IconButton
+          aria-label="Pesquisar bloco"
+          onClick={handleToggle}
+          bgColor="white"
+          icon={<MdSearch />}
+          size="sm"
+          shadow="lg"
+        />
+      </Tooltip>
+
+      {isOpen && (
+        <Box
+          position="fixed"
+          top="20px"
+          left="50%"
+          transform="translateX(-35%)"
+          zIndex="popover"
+          w="600px"
+          maxW="92vw"
+          bg="white"
+          rounded="md"
+          shadow="2xl"
+          border="1px solid"
+          borderColor="gray.200"
+          p="3"
+        >
+          <InputGroup size="md">
+            <InputLeftElement pointerEvents="none">
+              <MdSearch color="gray" />
+            </InputLeftElement>
+            <Input
+              ref={inputRef}
+              value={searchValue}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setSearchValue(e.target.value)
+              }
+              onKeyDown={handleKeyDown}
+              placeholder="Pesquisar bloco pelo título"
+              rounded="md"
+            />
+          </InputGroup>
+
+          {hasQuery && (
+            <Flex
+              direction="column"
+              mt="2"
+              maxH="50vh"
+              overflowY="auto"
+              role="menu"
+            >
+              {results.length > 0 ? (
+                results.map((block) => (
+                  <Button
+                    key={block.id}
+                    onClick={handleResultClick(
+                      block.id,
+                      block.graphCoordinates.x,
+                      block.graphCoordinates.y
+                    )}
+                    size="sm"
+                    variant="ghost"
+                    colorScheme="gray"
+                    justifyContent="flex-start"
+                    fontWeight="normal"
+                    role="menuitem"
+                    minH={'40px'}
+                  >
+                    <Text isTruncated>{block.title || 'Sem título'}</Text>
+                  </Button>
+                ))
+              ) : (
+                <Text fontSize="sm" color="gray.500" px="2" py="1">
+                  Nenhum bloco encontrado
+                </Text>
+              )}
+            </Flex>
+          )}
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/apps/builder/components/editor/BoardMenuButtonSearch.tsx
+++ b/apps/builder/components/editor/BoardMenuButtonSearch.tsx
@@ -83,9 +83,9 @@ export const BoardMenuButtonSearch = (props: BoxProps) => {
 
   return (
     <Box ref={containerRef} w="fit-content" {...props}>
-      <Tooltip label="Pesquisar bloco">
+      <Tooltip label="Pesquisar grupo">
         <IconButton
-          aria-label="Pesquisar bloco"
+          aria-label="Pesquisar grupo"
           onClick={handleToggle}
           bgColor="white"
           icon={<MdSearch />}
@@ -121,7 +121,7 @@ export const BoardMenuButtonSearch = (props: BoxProps) => {
                 setSearchValue(e.target.value)
               }
               onKeyDown={handleKeyDown}
-              placeholder="Pesquisar bloco pelo título"
+              placeholder="Pesquisar grupo pelo título"
               rounded="md"
             />
           </InputGroup>
@@ -156,7 +156,7 @@ export const BoardMenuButtonSearch = (props: BoxProps) => {
                 ))
               ) : (
                 <Text fontSize="sm" color="gray.500" px="2" py="1">
-                  Nenhum bloco encontrado
+                  Nenhum grupo encontrado
                 </Text>
               )}
             </Flex>

--- a/apps/builder/components/editor/todoList/emptyFieldsItem/index.tsx
+++ b/apps/builder/components/editor/todoList/emptyFieldsItem/index.tsx
@@ -3,28 +3,20 @@ import { StepIcon } from 'components/editor/StepsSideBar/StepIcon'
 import { StepTitle } from '../style'
 import { StepTypeLabel } from 'components/editor/StepsSideBar/StepTypeLabel'
 import { colors } from 'libs/theme'
-import { useGraphPosition } from 'contexts/GraphContext'
 import { EmptyFields } from 'hooks/EmptyFields/useEmptyFields'
 import { useTypebot } from 'contexts/TypebotContext'
+import { useGraphFocus } from 'hooks/useGraphFocus'
 
 const EmptyFieldsItem = ({ item }: { item: EmptyFields }) => {
-  const { setGraphPosition } = useGraphPosition()
   const { typebot } = useTypebot()
+  const { focusOnCoordinates } = useGraphFocus()
 
   const focusOnField = () => {
     const graphCoordinates = typebot?.blocks.find((b) =>
       b.steps.find((s) => s.id === item.step.id)
     )?.graphCoordinates
 
-    if (!graphCoordinates) return
-    const centerX = window.innerWidth / 2
-    const centerY = window.innerHeight / 2
-    const averageSizeCard = 315
-
-    const calcX = centerX - averageSizeCard / 2 - graphCoordinates.x
-    const calcY = centerY - averageSizeCard / 2 - graphCoordinates.y
-
-    setGraphPosition({ x: calcX, y: calcY, scale: 1 })
+    focusOnCoordinates(graphCoordinates)
   }
 
   const hasCustomErrorMessage = item?.errorMessage && 

--- a/apps/builder/components/editor/todoList/emptyFieldsItem/index.tsx
+++ b/apps/builder/components/editor/todoList/emptyFieldsItem/index.tsx
@@ -3,12 +3,12 @@ import { StepIcon } from 'components/editor/StepsSideBar/StepIcon'
 import { StepTitle } from '../style'
 import { StepTypeLabel } from 'components/editor/StepsSideBar/StepTypeLabel'
 import { colors } from 'libs/theme'
-import { useGraph } from 'contexts/GraphContext'
+import { useGraphPosition } from 'contexts/GraphContext'
 import { EmptyFields } from 'hooks/EmptyFields/useEmptyFields'
 import { useTypebot } from 'contexts/TypebotContext'
 
 const EmptyFieldsItem = ({ item }: { item: EmptyFields }) => {
-  const { setGraphPosition } = useGraph()
+  const { setGraphPosition } = useGraphPosition()
   const { typebot } = useTypebot()
 
   const focusOnField = () => {

--- a/apps/builder/components/editor/todoList/groupsWithoutConectionItem/index.tsx
+++ b/apps/builder/components/editor/todoList/groupsWithoutConectionItem/index.tsx
@@ -1,10 +1,10 @@
 import { Flex } from '@chakra-ui/react'
 import { StepTitle } from '../style'
 import { Block } from 'models'
-import { useGraph } from 'contexts/GraphContext'
+import { useGraphPosition } from 'contexts/GraphContext'
 
 const GroupsWithoutConnectionItem = ({ item }: { item: Block }) => {
-  const { setGraphPosition } = useGraph()
+  const { setGraphPosition } = useGraphPosition()
 
   const focusOnField = () => {
     if (!item.graphCoordinates) return

--- a/apps/builder/components/octaComponents/OctaSelect/OctaSelect.tsx
+++ b/apps/builder/components/octaComponents/OctaSelect/OctaSelect.tsx
@@ -106,12 +106,11 @@ const OctaSelect = (props: OctaSelectProps) => {
     ) as HTMLElement
     if (!settingsModal) return
 
-    if (isComponentVisible) {
-      settingsModal.style.overflow = 'hidden'
+    settingsModal.style.overflow = isComponentVisible ? 'hidden' : 'auto'
 
-      return
+    return () => {
+      settingsModal.style.overflow = 'auto'
     }
-    settingsModal.style.overflow = 'auto'
   }, [dialogRef, isComponentVisible])
 
   useEffect(() => {

--- a/apps/builder/components/results/SubmissionsTable/SubmissionsTable.tsx
+++ b/apps/builder/components/results/SubmissionsTable/SubmissionsTable.tsx
@@ -54,6 +54,7 @@ export const SubmissionsTable = ({
     }
     const observer = new IntersectionObserver(handleObserver, options)
     if (bottomElement.current) observer.observe(bottomElement.current)
+    return () => observer.disconnect()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bottomElement.current])
 

--- a/apps/builder/components/shared/ContextMenu.tsx
+++ b/apps/builder/components/shared/ContextMenu.tsx
@@ -40,9 +40,10 @@ export function ContextMenu<T extends HTMLElement = HTMLElement>(
   const { readonly = false } = props
   useEffect(() => {
     if (isOpened) {
-      setTimeout(() => {
+      let innerTimer: ReturnType<typeof setTimeout> | undefined
+      const outerTimer = setTimeout(() => {
         setIsRendered(true)
-        setTimeout(() => {
+        innerTimer = setTimeout(() => {
           setIsDeferredOpen(true)
         })
       })
@@ -56,6 +57,8 @@ export function ContextMenu<T extends HTMLElement = HTMLElement>(
       document.addEventListener('contextmenu', handleGlobalContextMenu, true)
 
       return () => {
+        clearTimeout(outerTimer)
+        clearTimeout(innerTimer)
         document.removeEventListener('contextmenu', handleGlobalContextMenu, true)
       }
     } else {

--- a/apps/builder/components/shared/Graph/Edges/DrawingEdge.tsx
+++ b/apps/builder/components/shared/Graph/Edges/DrawingEdge.tsx
@@ -1,6 +1,11 @@
 import { useEventListener } from '@chakra-ui/react'
 import assert from 'assert'
-import { useGraph, ConnectingIds } from 'contexts/GraphContext'
+import {
+  useGraph,
+  useBlockCoordinates,
+  useGraphPosition,
+  ConnectingIds,
+} from 'contexts/GraphContext'
 import { useTypebot } from 'contexts/TypebotContext/TypebotContext'
 import { colors } from 'libs/theme'
 import React, { useMemo, useState } from 'react'
@@ -12,20 +17,21 @@ import {
 
 export const DrawingEdge = () => {
   const {
-    graphPosition,
     setConnectingIds,
     connectingIds,
     sourceEndpoints,
     targetEndpoints,
-    blocksCoordinates,
   } = useGraph()
+  const { graphPosition } = useGraphPosition()
   const { createEdge } = useTypebot()
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
 
-  const sourceBlockCoordinates =
-    blocksCoordinates && blocksCoordinates[connectingIds?.source.blockId ?? '']
-  const targetBlockCoordinates =
-    blocksCoordinates && blocksCoordinates[connectingIds?.target?.blockId ?? '']
+  const sourceBlockCoordinates = useBlockCoordinates(
+    connectingIds?.source.blockId
+  )
+  const targetBlockCoordinates = useBlockCoordinates(
+    connectingIds?.target?.blockId
+  )
 
   const sourceTop = useMemo(() => {
     if (!connectingIds) return 0

--- a/apps/builder/components/shared/Graph/Edges/DropOffEdge.tsx
+++ b/apps/builder/components/shared/Graph/Edges/DropOffEdge.tsx
@@ -1,5 +1,9 @@
 import { VStack, Tag, Text, Tooltip } from '@chakra-ui/react'
-import { useGraph } from 'contexts/GraphContext'
+import {
+  useBlockCoordinates,
+  useGraph,
+  useGraphPosition,
+} from 'contexts/GraphContext'
 import { useTypebot } from 'contexts/TypebotContext'
 import { useWorkspace } from 'contexts/WorkspaceContext'
 import React, { useMemo } from 'react'
@@ -24,8 +28,10 @@ export const DropOffEdge = ({
   onUnlockProPlanClick,
 }: Props) => {
   const { workspace } = useWorkspace()
-  const { sourceEndpoints, blocksCoordinates, graphPosition } = useGraph()
+  const { sourceEndpoints } = useGraph()
+  const { graphPosition } = useGraphPosition()
   const { publishedTypebot } = useTypebot()
+  const blockCoordinates = useBlockCoordinates(blockId)
 
   const isUserOnFreePlan = isFreePlan(workspace)
 
@@ -65,13 +71,13 @@ export const DropOffEdge = ({
         graphScale: graphPosition.scale,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [block?.steps, sourceEndpoints, blocksCoordinates]
+    [block?.steps, sourceEndpoints, blockCoordinates]
   )
 
   const labelCoordinates = useMemo(() => {
-    if (!blocksCoordinates[blockId]) return
-    return computeSourceCoordinates(blocksCoordinates[blockId], sourceTop ?? 0)
-  }, [blocksCoordinates, blockId, sourceTop])
+    if (!blockCoordinates) return
+    return computeSourceCoordinates(blockCoordinates, sourceTop ?? 0)
+  }, [blockCoordinates, sourceTop])
 
   if (!labelCoordinates) return <></>
   return (

--- a/apps/builder/components/shared/Graph/Edges/Edge.tsx
+++ b/apps/builder/components/shared/Graph/Edges/Edge.tsx
@@ -1,4 +1,9 @@
-import { Coordinates, useGraph } from 'contexts/GraphContext'
+import {
+  Coordinates,
+  useBlockCoordinates,
+  useGraph,
+  useGraphPosition,
+} from 'contexts/GraphContext'
 import React, { useEffect, useMemo, useState } from 'react'
 import {
   getAnchorsPosition,
@@ -33,21 +38,18 @@ export const Edge = ({
     previewingEdge,
     sourceEndpoints,
     targetEndpoints,
-    blocksCoordinates,
-    graphPosition,
     isReadOnly,
     setPreviewingEdge,
   } = useGraph()
+  const { graphPosition } = useGraphPosition()
   const [isMouseOver, setIsMouseOver] = useState(false)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [edgeMenuPosition, setEdgeMenuPosition] = useState({ x: 0, y: 0 })
 
   const isPreviewing = isMouseOver || previewingEdge?.id === edge.id
 
-  const sourceBlockCoordinates =
-    blocksCoordinates && blocksCoordinates[edge.from.blockId]
-  const targetBlockCoordinates =
-    blocksCoordinates && blocksCoordinates[edge.to.blockId]
+  const sourceBlockCoordinates = useBlockCoordinates(edge.from.blockId)
+  const targetBlockCoordinates = useBlockCoordinates(edge.to.blockId)
 
   const sourceTop = useMemo(() => {
     if (!sourceEndpoints || !graphPosition) return 0

--- a/apps/builder/components/shared/Graph/Edges/Edge.tsx
+++ b/apps/builder/components/shared/Graph/Edges/Edge.tsx
@@ -4,7 +4,7 @@ import {
   useGraph,
   useGraphPosition,
 } from 'contexts/GraphContext'
-import React, { memo, useEffect, useMemo, useState } from 'react'
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react'
 import {
   getAnchorsPosition,
   computeEdgePath,
@@ -43,25 +43,49 @@ export const Edge = memo(({ edge }: { edge: EdgeProps }) => {
   const sourceBlockCoordinates = useBlockCoordinates(edge.from.blockId)
   const targetBlockCoordinates = useBlockCoordinates(edge.to.blockId)
 
-  const sourceTop = useMemo(() => {
-    if (!sourceEndpoints || !graphPosition) return 0
-    return getEndpointTopOffset({
+  // Offset do endpoint DENTRO do bloco (em coordenadas de mundo). É invariante à
+  // posição do bloco, então o medimos via DOM apenas quando o board/endpoints
+  // mudam (bloco em repouso, DOM bate com a coordenada). Durante o arraste de um
+  // bloco o Y do edge passa a ser `coordenada-live-do-bloco + offset` — segue o
+  // card sem `getBoundingClientRect` por frame.
+  const sourceOffsetRef = useRef<number>(20)
+  const targetOffsetRef = useRef<number>(20)
+
+  useMemo(() => {
+    if (!sourceEndpoints || !graphPosition) return
+    const domTop = getEndpointTopOffset({
       endpoints: sourceEndpoints,
       graphOffsetY: graphPosition.y,
       endpointId: getSourceEndpointId(edge),
       graphScale: graphPosition.scale,
     })
+    if (domTop !== undefined && sourceBlockCoordinates)
+      sourceOffsetRef.current = domTop - sourceBlockCoordinates.y
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sourceEndpoints, graphPosition?.y, graphPosition?.scale, edge])
 
-  const targetTop = useMemo(() => {
-    if (!targetEndpoints || !graphPosition) return 0
-    return getEndpointTopOffset({
+  useMemo(() => {
+    if (!targetEndpoints || !graphPosition || !edge?.to.stepId) return
+    const domTop = getEndpointTopOffset({
       endpoints: targetEndpoints,
       graphOffsetY: graphPosition.y,
-      endpointId: edge?.to.stepId,
+      endpointId: edge.to.stepId,
       graphScale: graphPosition.scale,
     })
-  }, [targetEndpoints, graphPosition?.y, edge?.to.stepId, graphPosition?.scale])
+    if (domTop !== undefined && targetBlockCoordinates)
+      targetOffsetRef.current = domTop - targetBlockCoordinates.y
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetEndpoints, graphPosition?.y, graphPosition?.scale, edge?.to.stepId])
+
+  const sourceTop = sourceBlockCoordinates
+    ? sourceBlockCoordinates.y + sourceOffsetRef.current
+    : undefined
+
+  // Sem stepId é um alvo-bloco → ancora no topo do bloco (targetTop indefinido).
+  const targetTop =
+    edge?.to.stepId && targetBlockCoordinates
+      ? targetBlockCoordinates.y + targetOffsetRef.current
+      : undefined
 
   const path = useMemo(() => {
     if (!sourceBlockCoordinates || !targetBlockCoordinates) return ``
@@ -69,7 +93,7 @@ export const Edge = memo(({ edge }: { edge: EdgeProps }) => {
     // `sourceTop` fica indefinido. Caímos para uma âncora no topo do bloco de
     // origem para o edge continuar visível (bloco-a-bloco). Em zoom normal o
     // endpoint real é usado e a ancoragem é precisa.
-    const effectiveSourceTop = sourceTop || sourceBlockCoordinates.y + 20
+    const effectiveSourceTop = sourceTop ?? sourceBlockCoordinates.y + 20
     const anchorsPosition = getAnchorsPosition({
       sourceBlockCoordinates,
       targetBlockCoordinates,

--- a/apps/builder/components/shared/Graph/Edges/Edge.tsx
+++ b/apps/builder/components/shared/Graph/Edges/Edge.tsx
@@ -43,11 +43,6 @@ export const Edge = memo(({ edge }: { edge: EdgeProps }) => {
   const sourceBlockCoordinates = useBlockCoordinates(edge.from.blockId)
   const targetBlockCoordinates = useBlockCoordinates(edge.to.blockId)
 
-  // Offset do endpoint DENTRO do bloco (em coordenadas de mundo). É invariante à
-  // posição do bloco, então o medimos via DOM apenas quando o board/endpoints
-  // mudam (bloco em repouso, DOM bate com a coordenada). Durante o arraste de um
-  // bloco o Y do edge passa a ser `coordenada-live-do-bloco + offset` — segue o
-  // card sem `getBoundingClientRect` por frame.
   const sourceOffsetRef = useRef<number>(20)
   const targetOffsetRef = useRef<number>(20)
 
@@ -81,7 +76,6 @@ export const Edge = memo(({ edge }: { edge: EdgeProps }) => {
     ? sourceBlockCoordinates.y + sourceOffsetRef.current
     : undefined
 
-  // Sem stepId é um alvo-bloco → ancora no topo do bloco (targetTop indefinido).
   const targetTop =
     edge?.to.stepId && targetBlockCoordinates
       ? targetBlockCoordinates.y + targetOffsetRef.current
@@ -89,10 +83,6 @@ export const Edge = memo(({ edge }: { edge: EdgeProps }) => {
 
   const path = useMemo(() => {
     if (!sourceBlockCoordinates || !targetBlockCoordinates) return ``
-    // Em LOD (zoom-out) o bloco vira caixa e não registra endpoints, então
-    // `sourceTop` fica indefinido. Caímos para uma âncora no topo do bloco de
-    // origem para o edge continuar visível (bloco-a-bloco). Em zoom normal o
-    // endpoint real é usado e a ancoragem é precisa.
     const effectiveSourceTop = sourceTop ?? sourceBlockCoordinates.y + 20
     const anchorsPosition = getAnchorsPosition({
       sourceBlockCoordinates,

--- a/apps/builder/components/shared/Graph/Edges/Edge.tsx
+++ b/apps/builder/components/shared/Graph/Edges/Edge.tsx
@@ -72,12 +72,16 @@ export const Edge = ({
   }, [targetEndpoints, graphPosition?.y, edge?.to.stepId, graphPosition?.scale])
 
   const path = useMemo(() => {
-    if (!sourceBlockCoordinates || !targetBlockCoordinates || !sourceTop)
-      return ``
+    if (!sourceBlockCoordinates || !targetBlockCoordinates) return ``
+    // Em LOD (zoom-out) o bloco vira caixa e não registra endpoints, então
+    // `sourceTop` fica indefinido. Caímos para uma âncora no topo do bloco de
+    // origem para o edge continuar visível (bloco-a-bloco). Em zoom normal o
+    // endpoint real é usado e a ancoragem é precisa.
+    const effectiveSourceTop = sourceTop || sourceBlockCoordinates.y + 20
     const anchorsPosition = getAnchorsPosition({
       sourceBlockCoordinates,
       targetBlockCoordinates,
-      sourceTop,
+      sourceTop: effectiveSourceTop,
       targetTop,
       graphScale: graphPosition.scale,
     })

--- a/apps/builder/components/shared/Graph/Edges/Edge.tsx
+++ b/apps/builder/components/shared/Graph/Edges/Edge.tsx
@@ -4,14 +4,14 @@ import {
   useGraph,
   useGraphPosition,
 } from 'contexts/GraphContext'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { memo, useEffect, useMemo, useState } from 'react'
 import {
   getAnchorsPosition,
   computeEdgePath,
   getEndpointTopOffset,
   getSourceEndpointId,
 } from 'services/graph'
-import { Block, Edge as EdgeProps } from 'models'
+import { Edge as EdgeProps } from 'models'
 import { Portal, useDisclosure } from '@chakra-ui/react'
 import { useTypebot } from 'contexts/TypebotContext'
 import { EdgeMenu } from './EdgeMenu'
@@ -24,15 +24,7 @@ export type AnchorsPositionProps = {
   totalSegments: number
 }
 
-export const Edge = ({
-  edge,
-  block,
-  visibleItems,
-}: {
-  edge: EdgeProps
-  block: Block
-  visibleItems: Block[]
-}) => {
+export const Edge = memo(({ edge }: { edge: EdgeProps }) => {
   const { deleteEdge } = useTypebot()
   const {
     previewingEdge,
@@ -150,14 +142,16 @@ export const Edge = ({
         markerEnd={isPreviewing ? 'url(#blue-arrow)' : 'url(#arrow)'}
         fill="none"
       />
-      <Portal>
-        <EdgeMenu
-          isOpen={isOpen}
-          position={edgeMenuPosition}
-          onDeleteEdge={handleDeleteEdge}
-          onClose={onClose}
-        />
-      </Portal>
+      {isOpen && (
+        <Portal>
+          <EdgeMenu
+            isOpen={isOpen}
+            position={edgeMenuPosition}
+            onDeleteEdge={handleDeleteEdge}
+            onClose={onClose}
+          />
+        </Portal>
+      )}
     </>
   )
-}
+})

--- a/apps/builder/components/shared/Graph/Edges/Edges.tsx
+++ b/apps/builder/components/shared/Graph/Edges/Edges.tsx
@@ -1,38 +1,20 @@
 import { chakra } from '@chakra-ui/react'
 import { colors } from 'libs/theme'
-import { Block, Edge as EdgeProps } from 'models'
-import React, { memo, useMemo } from 'react'
+import { Edge as EdgeProps } from 'models'
+import React, { memo } from 'react'
 import { AnswersCount } from 'services/analytics'
 import { DrawingEdge } from './DrawingEdge'
 import { DropOffEdge } from './DropOffEdge'
 import { Edge } from './Edge'
 
-const getBlockMap = (blocks: Block[]) => {
-  const map = new Map<string, Block>()
-  for (const block of blocks) {
-    map.set(block.id, block)
-  }
-  return map
-}
-
 type Props = {
-  visibleItems: Block[]
   edges: EdgeProps[]
-  blocks: Block[]
   answersCounts?: AnswersCount[]
   onUnlockProPlanClick?: () => void
 }
 
 export const Edges = memo(
-  ({
-    edges,
-    blocks,
-    answersCounts,
-    onUnlockProPlanClick,
-    visibleItems,
-  }: Props) => {
-    const blockMap = useMemo(() => getBlockMap(blocks), [blocks])
-
+  ({ edges, answersCounts, onUnlockProPlanClick }: Props) => {
     return (
       <chakra.svg
         width="full"
@@ -45,18 +27,9 @@ export const Edges = memo(
         shapeRendering="geometricPrecision"
       >
         <DrawingEdge />
-        {edges.map((edge) => {
-          const block = blockMap.get(edge.from.blockId)
-
-          return (
-            <Edge
-              visibleItems={visibleItems ?? []}
-              block={block || ({} as Block)}
-              key={edge.id}
-              edge={edge}
-            />
-          )
-        })}
+        {edges.map((edge) => (
+          <Edge key={edge.id} edge={edge} />
+        ))}
         {answersCounts?.slice(1)?.map((answerCount) => (
           <DropOffEdge
             key={answerCount.blockId}

--- a/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
+++ b/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
@@ -11,7 +11,7 @@ export const SourceEndpoint = ({
   source: Source
 }) => {
   const [ranOnce, setRanOnce] = useState(false)
-  const { setConnectingIds, addSourceEndpoint, previewingEdge } = useGraph()
+  const { setConnectingIds, addSourceEndpoint, removeSourceEndpoint, previewingEdge } = useGraph()
   const coordinatesReady = useCoordinatesReady()
   const ref = useRef<HTMLDivElement | null>(null)
 
@@ -24,11 +24,9 @@ export const SourceEndpoint = ({
   useEffect(() => {
     if (ranOnce || !ref.current || !coordinatesReady) return
     const id = source.itemId ?? source.stepId
-    addSourceEndpoint({
-      id,
-      ref,
-    })
+    addSourceEndpoint({ id, ref })
     setRanOnce(true)
+    return () => removeSourceEndpoint(id)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref.current, coordinatesReady])
 

--- a/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
+++ b/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
@@ -1,6 +1,6 @@
 import { BoxProps, Flex } from '@chakra-ui/react'
 import { useCoordinatesReady, useGraph } from 'contexts/GraphContext'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotExtras } from 'contexts/TypebotContext'
 import { Source } from 'models'
 import React, { MouseEvent, useEffect, useRef, useState } from 'react'
 
@@ -11,7 +11,7 @@ export const SourceEndpoint = ({
   source: Source
 }) => {
   const [ranOnce, setRanOnce] = useState(false)
-  const { setHideEdges } = useTypebot()
+  const { setHideEdges } = useTypebotExtras()
   const { setConnectingIds, addSourceEndpoint, previewingEdge } = useGraph()
   const coordinatesReady = useCoordinatesReady()
   const ref = useRef<HTMLDivElement | null>(null)

--- a/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
+++ b/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
@@ -1,5 +1,5 @@
 import { BoxProps, Flex } from '@chakra-ui/react'
-import { useGraph } from 'contexts/GraphContext'
+import { useCoordinatesReady, useGraph } from 'contexts/GraphContext'
 import { useTypebot } from 'contexts/TypebotContext'
 import { Source } from 'models'
 import React, { MouseEvent, useEffect, useRef, useState } from 'react'
@@ -12,12 +12,8 @@ export const SourceEndpoint = ({
 }) => {
   const [ranOnce, setRanOnce] = useState(false)
   const { setHideEdges } = useTypebot()
-  const {
-    setConnectingIds,
-    addSourceEndpoint,
-    blocksCoordinates,
-    previewingEdge,
-  } = useGraph()
+  const { setConnectingIds, addSourceEndpoint, previewingEdge } = useGraph()
+  const coordinatesReady = useCoordinatesReady()
   const ref = useRef<HTMLDivElement | null>(null)
 
   const handleMouseDown = (e: MouseEvent<HTMLDivElement>) => {
@@ -28,8 +24,7 @@ export const SourceEndpoint = ({
   }
 
   useEffect(() => {
-    if (ranOnce || !ref.current || Object.keys(blocksCoordinates).length === 0)
-      return
+    if (ranOnce || !ref.current || !coordinatesReady) return
     const id = source.itemId ?? source.stepId
     addSourceEndpoint({
       id,
@@ -37,9 +32,8 @@ export const SourceEndpoint = ({
     })
     setRanOnce(true)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref.current, blocksCoordinates])
+  }, [ref.current, coordinatesReady])
 
-  if (!blocksCoordinates) return <></>
   return (
     <Flex
       ref={ref}

--- a/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
+++ b/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
@@ -11,7 +11,6 @@ export const SourceEndpoint = ({
   source: Source
 }) => {
   const [ranOnce, setRanOnce] = useState(false)
-  const { setHideEdges } = useTypebotExtras()
   const { setConnectingIds, addSourceEndpoint, previewingEdge } = useGraph()
   const coordinatesReady = useCoordinatesReady()
   const ref = useRef<HTMLDivElement | null>(null)
@@ -20,7 +19,6 @@ export const SourceEndpoint = ({
     e.stopPropagation()
     e.preventDefault()
     setConnectingIds({ source })
-    setHideEdges(false)
   }
 
   useEffect(() => {

--- a/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
+++ b/apps/builder/components/shared/Graph/Endpoints/SourceEndpoint.tsx
@@ -1,8 +1,7 @@
 import { BoxProps, Flex } from '@chakra-ui/react'
 import { useCoordinatesReady, useGraph } from 'contexts/GraphContext'
-import { useTypebotExtras } from 'contexts/TypebotContext'
 import { Source } from 'models'
-import React, { MouseEvent, useEffect, useRef, useState } from 'react'
+import React, { MouseEvent, useEffect, useRef } from 'react'
 
 export const SourceEndpoint = ({
   source,
@@ -10,7 +9,6 @@ export const SourceEndpoint = ({
 }: BoxProps & {
   source: Source
 }) => {
-  const [ranOnce, setRanOnce] = useState(false)
   const { setConnectingIds, addSourceEndpoint, removeSourceEndpoint, previewingEdge } = useGraph()
   const coordinatesReady = useCoordinatesReady()
   const ref = useRef<HTMLDivElement | null>(null)
@@ -22,13 +20,12 @@ export const SourceEndpoint = ({
   }
 
   useEffect(() => {
-    if (ranOnce || !ref.current || !coordinatesReady) return
+    if (!ref.current || !coordinatesReady) return
     const id = source.itemId ?? source.stepId
     addSourceEndpoint({ id, ref })
-    setRanOnce(true)
     return () => removeSourceEndpoint(id)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref.current, coordinatesReady])
+  }, [coordinatesReady])
 
   return (
     <Flex

--- a/apps/builder/components/shared/Graph/Endpoints/TargetEndpoint.tsx
+++ b/apps/builder/components/shared/Graph/Endpoints/TargetEndpoint.tsx
@@ -10,15 +10,13 @@ export const TargetEndpoint = ({
   stepId: string
   isVisible?: boolean
 }) => {
-  const { addTargetEndpoint } = useGraph()
+  const { addTargetEndpoint, removeTargetEndpoint } = useGraph()
   const ref = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     if (!ref.current) return
-    addTargetEndpoint({
-      id: stepId,
-      ref,
-    })
+    addTargetEndpoint({ id: stepId, ref })
+    return () => removeTargetEndpoint(stepId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref])
 

--- a/apps/builder/components/shared/Graph/Graph.tsx
+++ b/apps/builder/components/shared/Graph/Graph.tsx
@@ -468,9 +468,6 @@ export const Graph = memo(
             position="absolute"
             style={{
               transform,
-              // Sem easing ao arrastar bloco OU ao dar pan no board (arraste):
-              // o transform segue o cursor 1:1. Mantém o easing de 0.1s só para
-              // o scroll, onde ele suaviza os passos discretos da roda.
               transition: draggingBlockId || isMovingBoard ? '0s' : '0.1s',
             }}
             willChange="transform"

--- a/apps/builder/components/shared/Graph/Graph.tsx
+++ b/apps/builder/components/shared/Graph/Graph.tsx
@@ -20,6 +20,7 @@ import {
   Coordinates,
   graphPositionDefaultValue,
   useGraph,
+  useGraphPosition,
 } from 'contexts/GraphContext'
 import { useStepDnd } from 'contexts/GraphDndContext'
 import { useTypebot } from 'contexts/TypebotContext/TypebotContext'
@@ -71,16 +72,18 @@ export const Graph = memo(
       setHideEdges,
     } = useTypebot()
     const {
-      setGraphPosition: setGlobalGraphPosition,
-      graphPosition: globalGraphPosition,
       setOpenedStepId,
       updateBlockCoordinates,
-      blocksCoordinates,
+      getBlockCoordinates,
       setPreviewingEdge,
       connectingIds,
       goToBegining,
       draggingBlockId,
     } = useGraph()
+    const {
+      setGraphPosition: setGlobalGraphPosition,
+      graphPosition: globalGraphPosition,
+    } = useGraphPosition()
 
     const [graphPosition, setGraphPosition] = useState(
       graphPositionDefaultValue
@@ -165,7 +168,7 @@ export const Graph = memo(
         return
 
       const blockCoordinates =
-        blocksCoordinates[draggingBlockId] ??
+        getBlockCoordinates(draggingBlockId) ??
         typebot?.blocks.find((block) => block.id === draggingBlockId)
           ?.graphCoordinates
 
@@ -181,7 +184,8 @@ export const Graph = memo(
         y: mouseWorld.y - blockCoordinates.y,
       }
       prevDraggingIdRef.current = draggingBlockId
-    }, [blocksCoordinates, draggingBlockId, typebot?.blocks, graphPosition])
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [draggingBlockId, typebot?.blocks, graphPosition])
 
     useEffect(() => {
       editorContainerRef.current = document.getElementById(

--- a/apps/builder/components/shared/Graph/Graph.tsx
+++ b/apps/builder/components/shared/Graph/Graph.tsx
@@ -146,9 +146,10 @@ export const Graph = memo(
       if (!typebot) return
       setIsMovingBoard(true)
       goToBegining()
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         setIsMovingBoard(false)
       }, showEdgesTimeOut)
+      return () => clearTimeout(timer)
     }, [])
 
     useEffect(() => {

--- a/apps/builder/components/shared/Graph/Graph.tsx
+++ b/apps/builder/components/shared/Graph/Graph.tsx
@@ -69,7 +69,6 @@ export const Graph = memo(
       redo,
       canUndo,
       canRedo,
-      setHideEdges,
     } = useTypebot()
     const {
       setOpenedStepId,
@@ -100,11 +99,9 @@ export const Graph = memo(
 
     useEffect(() => {
       if (isMovingBoard) {
-        setHideEdges(true)
       } else {
         const timeout = setTimeout(() => {
           if (!isMovingBoardRef.current) {
-            setHideEdges(false)
           }
         }, showEdgesTimeOut)
 

--- a/apps/builder/components/shared/Graph/Graph.tsx
+++ b/apps/builder/components/shared/Graph/Graph.tsx
@@ -354,11 +354,12 @@ export const Graph = memo(
     const onDrag = (_: DraggableEvent, draggableData: DraggableData) => {
       const { deltaX, deltaY } = draggableData
 
-      setGraphPosition({
-        ...graphPosition,
-        x: graphPosition.x + deltaX,
-        y: graphPosition.y + deltaY,
-      })
+
+      setGraphPosition((prev) => ({
+        ...prev,
+        x: prev.x + deltaX,
+        y: prev.y + deltaY,
+      }))
     }
 
     const handleMouseMove = (e: MouseEvent) => {
@@ -469,7 +470,10 @@ export const Graph = memo(
             position="absolute"
             style={{
               transform,
-              transition: draggingBlockId ? '0s' : '0.1s',
+              // Sem easing ao arrastar bloco OU ao dar pan no board (arraste):
+              // o transform segue o cursor 1:1. Mantém o easing de 0.1s só para
+              // o scroll, onde ele suaviza os passos discretos da roda.
+              transition: draggingBlockId || isMovingBoard ? '0s' : '0.1s',
             }}
             willChange="transform"
             transformOrigin="0px 0px 0px"

--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -3,7 +3,11 @@ import React, { memo, useMemo } from 'react'
 import { AnswersCount } from 'services/analytics'
 import { Edges } from './Edges'
 import { BlockNode } from './Nodes/BlockNode'
-import { useGraph } from 'contexts/GraphContext'
+import {
+  useAllBlocksCoordinates,
+  useGraph,
+  useGraphPosition,
+} from 'contexts/GraphContext'
 import { isItemVisible } from 'services/graph'
 import { Block } from 'models'
 
@@ -16,7 +20,9 @@ type Props = {
 const MyComponent = memo(
   ({ answersCounts, onUnlockProPlanClick, graphContainerRef }: Props) => {
     const { typebot, hideEdges } = useTypebot()
-    const { graphPosition, draggingBlockId, blocksCoordinates } = useGraph()
+    const { draggingBlockId } = useGraph()
+    const { graphPosition } = useGraphPosition()
+    const blocksCoordinates = useAllBlocksCoordinates()
 
     const visibleItems = useMemo(() => {
       if (!typebot?.blocks || !graphContainerRef.current) return []

--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -4,7 +4,6 @@ import { AnswersCount } from 'services/analytics'
 import { Edges } from './Edges'
 import { BlockNode } from './Nodes/BlockNode'
 import {
-  useAllBlocksCoordinates,
   useGraph,
   useGraphPosition,
 } from 'contexts/GraphContext'
@@ -33,7 +32,6 @@ const MyComponent = memo(
     const { typebot, hideEdges } = useTypebot()
     const { draggingBlockId } = useGraph()
     const { graphPosition } = useGraphPosition()
-    const blocksCoordinates = useAllBlocksCoordinates()
 
     const isSimplified =
       (typebot?.blocks?.length ?? 0) > LOD_MIN_BLOCKS &&
@@ -46,13 +44,10 @@ const MyComponent = memo(
       const containerHeight = graphContainerRef.current.offsetHeight
 
       const baseVisible = typebot.blocks.filter((block) => {
-        const liveCoordinates =
-          blocksCoordinates[block.id] ?? block.graphCoordinates
-
-        if (!liveCoordinates) return false
+        if (!block.graphCoordinates) return false
 
         return isItemVisible(
-          { ...block, graphCoordinates: liveCoordinates },
+          block,
           graphPosition,
           containerWidth,
           containerHeight,
@@ -78,7 +73,6 @@ const MyComponent = memo(
       graphPosition,
       graphContainerRef,
       draggingBlockId,
-      blocksCoordinates,
     ])
 
     // Renderiza a lista pesada de blocos em prioridade baixa: quando o conjunto

--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -87,7 +87,6 @@ const MyComponent = memo(
 
     return (
       <>
-        {!hideEdges && (
           <Edges
             visibleItems={visibleItems}
             edges={visibleEdges}
@@ -95,7 +94,6 @@ const MyComponent = memo(
             answersCounts={answersCounts}
             onUnlockProPlanClick={onUnlockProPlanClick}
           />
-        )}
 
         {visibleItems.map((block) => {
           const blockIndex = typebot?.blocks.findIndex((b) => b.id === block.id)

--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -1,5 +1,5 @@
 import { useTypebot } from 'contexts/TypebotContext'
-import React, { memo, useMemo } from 'react'
+import React, { memo, useDeferredValue, useMemo } from 'react'
 import { AnswersCount } from 'services/analytics'
 import { Edges } from './Edges'
 import { BlockNode } from './Nodes/BlockNode'
@@ -10,6 +10,12 @@ import {
 } from 'contexts/GraphContext'
 import { isItemVisible } from 'services/graph'
 import { Block } from 'models'
+
+// Abaixo deste zoom os blocos são renderizados em modo simplificado (LOD):
+// o conteúdo dos steps fica ilegível mesmo, então trocamos a subárvore pesada
+// (StepNodesList + previews + endpoints) por um resumo barato. É o que destrava
+// a navegação de bots gigantes em zoom-out (onde há centenas de blocos visíveis).
+export const LOD_SCALE_THRESHOLD = 0.5
 
 type Props = {
   answersCounts?: AnswersCount[]
@@ -23,6 +29,8 @@ const MyComponent = memo(
     const { draggingBlockId } = useGraph()
     const { graphPosition } = useGraphPosition()
     const blocksCoordinates = useAllBlocksCoordinates()
+
+    const isSimplified = graphPosition.scale < LOD_SCALE_THRESHOLD
 
     const visibleItems = useMemo(() => {
       if (!typebot?.blocks || !graphContainerRef.current) return []
@@ -66,13 +74,27 @@ const MyComponent = memo(
       blocksCoordinates,
     ])
 
+    // Renderiza a lista pesada de blocos em prioridade baixa: quando o conjunto
+    // visível muda (re-virtualização ao panar/dar zoom), o React mantém a lista
+    // antiga e monta a nova de forma interrompível, cedendo à interação — em vez
+    // de bloquear a main thread por um frame longo. `visibleItems` e
+    // `isSimplified` são deferidos juntos para o LOD e o conjunto ficarem sempre
+    // consistentes no mesmo render.
+    const { items: renderedItems, simplified: renderedSimplified } =
+      useDeferredValue(
+        useMemo(
+          () => ({ items: visibleItems, simplified: isSimplified }),
+          [visibleItems, isSimplified]
+        )
+      )
+
     const visibleItemsMap = useMemo(() => {
       const map = new Map<string, Block>()
-      visibleItems.forEach((item) => {
+      renderedItems.forEach((item) => {
         map.set(item.id, item)
       })
       return map
-    }, [visibleItems])
+    }, [renderedItems])
 
     const visibleEdges = useMemo(() => {
       if (!typebot?.edges) return []
@@ -96,19 +118,20 @@ const MyComponent = memo(
     return (
       <>
           <Edges
-            visibleItems={visibleItems}
+            visibleItems={renderedItems}
             edges={visibleEdges}
             blocks={typebot?.blocks ?? []}
             answersCounts={answersCounts}
             onUnlockProPlanClick={onUnlockProPlanClick}
           />
 
-        {visibleItems.map((block) => {
+        {renderedItems.map((block) => {
           const blockIndex = blockIndexById.get(block.id)
           return (
             <BlockNode
               block={block}
               blockIndex={blockIndex ?? 0}
+              simplified={renderedSimplified}
               key={block.id}
             />
           )

--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -124,11 +124,11 @@ const MyComponent = memo(
 
     return (
       <>
-          <Edges
+          {!hideEdges && <Edges
             edges={visibleEdges}
             answersCounts={answersCounts}
             onUnlockProPlanClick={onUnlockProPlanClick}
-          />
+          />}
 
         {renderedItems.map((block) => {
           const blockIndex = blockIndexById.get(block.id)

--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -10,15 +10,8 @@ import {
 import { isItemVisible } from 'services/graph'
 import { Block } from 'models'
 
-// Abaixo deste zoom os blocos são renderizados em modo simplificado (LOD):
-// o conteúdo dos steps fica ilegível mesmo, então trocamos a subárvore pesada
-// (StepNodesList + previews + endpoints) por um resumo barato. É o que destrava
-// a navegação de bots gigantes em zoom-out (onde há centenas de blocos visíveis).
 export const LOD_SCALE_THRESHOLD = 0.5
 
-// LOD só vale a pena com muitos blocos. Abaixo deste total, manter sempre o
-// detalhe completo (não simplificar) — fluxos pequenos não têm o problema de
-// renderizar centenas de subárvores, e perder detalhe ali seria só prejuízo.
 export const LOD_MIN_BLOCKS = 50
 
 type Props = {
@@ -75,12 +68,6 @@ const MyComponent = memo(
       draggingBlockId,
     ])
 
-    // Renderiza a lista pesada de blocos em prioridade baixa: quando o conjunto
-    // visível muda (re-virtualização ao panar/dar zoom), o React mantém a lista
-    // antiga e monta a nova de forma interrompível, cedendo à interação — em vez
-    // de bloquear a main thread por um frame longo. `visibleItems` e
-    // `isSimplified` são deferidos juntos para o LOD e o conjunto ficarem sempre
-    // consistentes no mesmo render.
     const { items: renderedItems, simplified: renderedSimplified } =
       useDeferredValue(
         useMemo(
@@ -108,8 +95,6 @@ const MyComponent = memo(
       })
     }, [typebot?.edges, visibleItemsMap])
 
-    // Índice por id calculado uma vez — evita um findIndex O(n) por bloco visível
-    // (era O(visíveis × total) a cada re-virtualização).
     const blockIndexById = useMemo(() => {
       const map = new Map<string, number>()
       typebot?.blocks.forEach((b, i) => map.set(b.id, i))

--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -85,6 +85,14 @@ const MyComponent = memo(
       })
     }, [typebot?.edges, visibleItemsMap])
 
+    // Índice por id calculado uma vez — evita um findIndex O(n) por bloco visível
+    // (era O(visíveis × total) a cada re-virtualização).
+    const blockIndexById = useMemo(() => {
+      const map = new Map<string, number>()
+      typebot?.blocks.forEach((b, i) => map.set(b.id, i))
+      return map
+    }, [typebot?.blocks])
+
     return (
       <>
           <Edges
@@ -96,7 +104,7 @@ const MyComponent = memo(
           />
 
         {visibleItems.map((block) => {
-          const blockIndex = typebot?.blocks.findIndex((b) => b.id === block.id)
+          const blockIndex = blockIndexById.get(block.id)
           return (
             <BlockNode
               block={block}

--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -17,6 +17,11 @@ import { Block } from 'models'
 // a navegação de bots gigantes em zoom-out (onde há centenas de blocos visíveis).
 export const LOD_SCALE_THRESHOLD = 0.5
 
+// LOD só vale a pena com muitos blocos. Abaixo deste total, manter sempre o
+// detalhe completo (não simplificar) — fluxos pequenos não têm o problema de
+// renderizar centenas de subárvores, e perder detalhe ali seria só prejuízo.
+export const LOD_MIN_BLOCKS = 50
+
 type Props = {
   answersCounts?: AnswersCount[]
   onUnlockProPlanClick?: () => void
@@ -30,7 +35,9 @@ const MyComponent = memo(
     const { graphPosition } = useGraphPosition()
     const blocksCoordinates = useAllBlocksCoordinates()
 
-    const isSimplified = graphPosition.scale < LOD_SCALE_THRESHOLD
+    const isSimplified =
+      (typebot?.blocks?.length ?? 0) > LOD_MIN_BLOCKS &&
+      graphPosition.scale < LOD_SCALE_THRESHOLD
 
     const visibleItems = useMemo(() => {
       if (!typebot?.blocks || !graphContainerRef.current) return []
@@ -118,9 +125,7 @@ const MyComponent = memo(
     return (
       <>
           <Edges
-            visibleItems={renderedItems}
             edges={visibleEdges}
-            blocks={typebot?.blocks ?? []}
             answersCounts={answersCounts}
             onUnlockProPlanClick={onUnlockProPlanClick}
           />

--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -12,7 +12,7 @@ import { Block } from 'models'
 
 export const LOD_SCALE_THRESHOLD = 0.5
 
-export const LOD_MIN_BLOCKS = 50
+export const LOD_MIN_BLOCKS = 20
 
 type Props = {
   answersCounts?: AnswersCount[]

--- a/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
@@ -54,6 +54,17 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
 
   const { setMouseOverBlock, mouseOverBlock } = useStepDnd()
 
+  // Quando o bloco sai da viewport (virtualização), garante que mouseOverBlock
+  // seja zerado. Sem isso, o useEventListener em StepNodesList de OUTROS blocos
+  // mantém uma closure sobre a div deste bloco (já desanexada do documento),
+  // impedindo o GC até o próximo re-render daqueles componentes.
+  useEffect(() => {
+    return () => {
+      setMouseOverBlock((prev) => (prev?.id === block.id ? undefined : prev))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const [isMouseDown, setIsMouseDown] = useState(false)
 
   const [isConnecting, setIsConnecting] = useState(false)
@@ -222,7 +233,7 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
                   title={block.title}
                   style={{
                     fontWeight: 600,
-                    fontSize: '14px',
+                    fontSize: '16px',
                     overflow: 'hidden',
                     whiteSpace: 'nowrap',
                     textOverflow: 'ellipsis',
@@ -269,21 +280,19 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
 
               {hasTypebot &&
                 (simplified ? (
-                  !isStartBlock && (
-                    <Stack spacing="2">
-                      {block.steps.map((step) => (
-                        <div
-                          key={step.id}
-                          style={{
-                            backgroundColor: '#E2E8F0',
-                            borderRadius: '6px',
-                            width: '100%',
-                            height: '120px',
-                          }}
-                        />
-                      ))}
-                    </Stack>
-                  )
+                  <Stack spacing="2">
+                    {block.steps.map((step) => (
+                      <div
+                        key={step.id}
+                        style={{
+                          backgroundColor: '#E2E8F0',
+                          borderRadius: '6px',
+                          width: '100%',
+                          height: '120px',
+                        }}
+                      />
+                    ))}
+                  </Stack>
                 ) : (
                   <StepNodesList
                     blockId={block.id}

--- a/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
@@ -9,7 +9,7 @@ import {
 } from '@chakra-ui/react'
 import React, { memo, useEffect, useRef, useState } from 'react'
 import { Block } from 'models'
-import { useGraph } from 'contexts/GraphContext'
+import { useBlockCoordinates, useGraph } from 'contexts/GraphContext'
 import { useStepDnd } from 'contexts/GraphDndContext'
 import { StepNodesList } from '../StepNode/StepNodesList'
 import { isDefined, isNotDefined } from 'utils'
@@ -33,14 +33,15 @@ export const BlockNode = memo(({ block, blockIndex }: Props) => {
     connectingIds,
     setConnectingIds,
     previewingEdge,
-    blocksCoordinates,
     updateBlockCoordinates,
     isReadOnly,
     focusedBlockId,
     setFocusedBlockId,
-    graphPosition,
+    getGraphPosition,
     setDraggingBlockId,
   } = useGraph()
+
+  const blockCoordinates = useBlockCoordinates(block.id)
 
   const { typebot, updateBlock, deleteBlock, duplicateBlock } = useTypebot()
 
@@ -64,8 +65,6 @@ export const BlockNode = memo(({ block, blockIndex }: Props) => {
 
   const isStartBlock =
     isDefined(block.steps[0]) && block.steps[0].type === 'start'
-
-  const blockCoordinates = blocksCoordinates[block.id]
 
   const blockRef = useRef<HTMLDivElement | null>(null)
 
@@ -121,9 +120,11 @@ export const BlockNode = memo(({ block, blockIndex }: Props) => {
 
     const { deltaX, deltaY } = draggableData
 
+    const { scale } = getGraphPosition()
+
     updateBlockCoordinates(block.id, {
-      x: blockCoordinates.x + deltaX / graphPosition.scale,
-      y: blockCoordinates.y + deltaY / graphPosition.scale,
+      x: blockCoordinates.x + deltaX / scale,
+      y: blockCoordinates.y + deltaY / scale,
     })
   }
 

--- a/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
@@ -54,10 +54,6 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
 
   const { setMouseOverBlock, mouseOverBlock } = useStepDnd()
 
-  // Quando o bloco sai da viewport (virtualização), garante que mouseOverBlock
-  // seja zerado. Sem isso, o useEventListener em StepNodesList de OUTROS blocos
-  // mantém uma closure sobre a div deste bloco (já desanexada do documento),
-  // impedindo o GC até o próximo re-render daqueles componentes.
   useEffect(() => {
     return () => {
       setMouseOverBlock((prev) => (prev?.id === block.id ? undefined : prev))

--- a/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
@@ -5,7 +5,6 @@ import {
   Flex,
   SlideFade,
   Stack,
-  Text,
   useOutsideClick,
 } from '@chakra-ui/react'
 import React, { memo, useEffect, useRef, useState } from 'react'
@@ -191,7 +190,9 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
               rounded="xl"
               bgColor="#ffffff"
               borderWidth="2px"
-              maxWidth="313px"
+              maxWidth={simplified ? '200px' : '313px'}
+              minWidth={simplified ? '313px' : undefined}
+              minHeight={simplified ? '200px' : undefined}
               borderColor={stackBorderColor(isOpened)}
               transition="border 300ms, box-shadow 200ms"
               pos="absolute"
@@ -216,7 +217,17 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
                   : ''
               }
             >
-              <Flex justifyContent="space-between" alignItems="center" gap="2">
+              {simplified ? (
+                <div
+                  style={{
+                    backgroundColor: '#E2E8F0',
+                    borderRadius: '6px',
+                    height: '20px',
+                    width: '100%',
+                  }}
+                />
+              ) : (
+                <Flex justifyContent="space-between" alignItems="center" gap="2">
                 <Editable
                   defaultValue={block.title}
                   onSubmit={handleTitleSubmit}
@@ -247,19 +258,25 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
                   />
                 )}
               </Flex>
+            )
+            }
 
               {hasTypebot &&
                 (simplified ? (
                   !isStartBlock && (
-                    <Text
-                      fontSize="sm"
-                      color="gray.500"
-                      px="1"
-                      userSelect="none"
-                    >
-                      {block.steps.length}{' '}
-                      {block.steps.length === 1 ? 'etapa' : 'etapas'}
-                    </Text>
+                    <Stack spacing="2">
+                      {block.steps.map((step) => (
+                        <div
+                          key={step.id}
+                          style={{
+                            backgroundColor: '#E2E8F0',
+                            borderRadius: '6px',
+                            width: '100%',
+                            height: '120px',
+                          }}
+                        />
+                      ))}
+                    </Stack>
                   )
                 ) : (
                   <StepNodesList

--- a/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   SlideFade,
   Stack,
+  Text,
   useOutsideClick,
 } from '@chakra-ui/react'
 import React, { memo, useEffect, useRef, useState } from 'react'
@@ -30,9 +31,10 @@ import OctaTooltip from 'components/octaComponents/OctaTooltip/OctaTooltip'
 type Props = {
   block: Block
   blockIndex: number
+  simplified?: boolean
 }
 
-export const BlockNode = memo(({ block, blockIndex }: Props) => {
+export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
   const {
     connectingIds,
     setConnectingIds,
@@ -246,15 +248,28 @@ export const BlockNode = memo(({ block, blockIndex }: Props) => {
                 )}
               </Flex>
 
-              {hasTypebot && (
-                <StepNodesList
-                  blockId={block.id}
-                  steps={block.steps}
-                  blockIndex={blockIndex}
-                  blockRef={ref}
-                  isStartBlock={isStartBlock}
-                />
-              )}
+              {hasTypebot &&
+                (simplified ? (
+                  !isStartBlock && (
+                    <Text
+                      fontSize="sm"
+                      color="gray.500"
+                      px="1"
+                      userSelect="none"
+                    >
+                      {block.steps.length}{' '}
+                      {block.steps.length === 1 ? 'etapa' : 'etapas'}
+                    </Text>
+                  )
+                ) : (
+                  <StepNodesList
+                    blockId={block.id}
+                    steps={block.steps}
+                    blockIndex={blockIndex}
+                    blockRef={ref}
+                    isStartBlock={isStartBlock}
+                  />
+                ))}
 
               {isFocused && !isStartBlock && (
                 <SlideFade

--- a/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
@@ -219,13 +219,19 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
             >
               {simplified ? (
                 <div
+                  title={block.title}
                   style={{
-                    backgroundColor: '#E2E8F0',
-                    borderRadius: '6px',
-                    height: '20px',
-                    width: '100%',
+                    fontWeight: 600,
+                    fontSize: '14px',
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                    padding: '0 4px',
+                    color: '#1B2A4A',
                   }}
-                />
+                >
+                  {block.title || 'Sem título'}
+                </div>
               ) : (
                 <Flex justifyContent="space-between" alignItems="center" gap="2">
                 <Editable

--- a/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
@@ -13,7 +13,11 @@ import { useBlockCoordinates, useGraph } from 'contexts/GraphContext'
 import { useStepDnd } from 'contexts/GraphDndContext'
 import { StepNodesList } from '../StepNode/StepNodesList'
 import { isDefined, isNotDefined } from 'utils'
-import { useTypebot } from 'contexts/TypebotContext/TypebotContext'
+import {
+  useTypebotActions,
+  useTypebotAvailableFor,
+  useHasTypebot,
+} from 'contexts/TypebotContext/TypebotContext'
 import { ContextMenu } from 'components/shared/ContextMenu'
 import { BlockNodeContextMenu } from './BlockNodeContextMenu'
 import { useDebounce } from 'use-debounce'
@@ -43,7 +47,9 @@ export const BlockNode = memo(({ block, blockIndex }: Props) => {
 
   const blockCoordinates = useBlockCoordinates(block.id)
 
-  const { typebot, updateBlock, deleteBlock, duplicateBlock } = useTypebot()
+  const { updateBlock, deleteBlock, duplicateBlock } = useTypebotActions()
+  const availableFor = useTypebotAvailableFor()
+  const hasTypebot = useHasTypebot()
 
   const { setMouseOverBlock, mouseOverBlock } = useStepDnd()
 
@@ -54,7 +60,7 @@ export const BlockNode = memo(({ block, blockIndex }: Props) => {
   const [isFocused, setIsFocused] = useState(false)
 
   const availableOnlyForEvent =
-    typebot?.availableFor?.length == 1 && typebot.availableFor.includes('event')
+    availableFor?.length == 1 && availableFor.includes('event')
 
   const showWarning = !availableOnlyForEvent
 
@@ -118,6 +124,8 @@ export const BlockNode = memo(({ block, blockIndex }: Props) => {
   const onDrag = (_: DraggableEvent, draggableData: DraggableData) => {
     _.preventDefault()
 
+    if (!blockCoordinates) return
+
     const { deltaX, deltaY } = draggableData
 
     const { scale } = getGraphPosition()
@@ -156,7 +164,7 @@ export const BlockNode = memo(({ block, blockIndex }: Props) => {
 
   const hasWarning = !block.hasConnection && showWarning
   const showEmptyConnectionAlert = () => !block.hasConnection && showWarning
-  const isAutomatedTasksBot = typebot?.availableFor.includes('automated-tasks')
+  const isAutomatedTasksBot = availableFor?.includes('automated-tasks')
   const emptyConnectionMessage = `Este bloco precisa se conectar e/ou receber uma conexão de outro bloco.`
 
   return (
@@ -238,7 +246,7 @@ export const BlockNode = memo(({ block, blockIndex }: Props) => {
                 )}
               </Flex>
 
-              {typebot && (
+              {hasTypebot && (
                 <StepNodesList
                   blockId={block.id}
                   steps={block.steps}

--- a/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/BlockNode/BlockNode.tsx
@@ -1,14 +1,16 @@
 import {
+  Box,
   Editable,
   EditableInput,
   EditablePreview,
   Flex,
   SlideFade,
   Stack,
+  Tooltip,
   useOutsideClick,
 } from '@chakra-ui/react'
 import React, { memo, useEffect, useRef, useState } from 'react'
-import { Block } from 'models'
+import { Block, StepType } from 'models'
 import { useBlockCoordinates, useGraph } from 'contexts/GraphContext'
 import { useStepDnd } from 'contexts/GraphDndContext'
 import { StepNodesList } from '../StepNode/StepNodesList'
@@ -26,6 +28,8 @@ import { DraggableCore, DraggableData, DraggableEvent } from 'react-draggable'
 import { BlockFocusToolbar } from './BlockFocusToolbar'
 import { WarningTwoIcon } from '@chakra-ui/icons'
 import OctaTooltip from 'components/octaComponents/OctaTooltip/OctaTooltip'
+import { StepIcon } from 'components/editor/StepsSideBar/StepIcon'
+import { StepTypeLabel } from 'components/editor/StepsSideBar/StepTypeLabel'
 
 type Props = {
   block: Block
@@ -225,20 +229,27 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
               }
             >
               {simplified ? (
-                <div
-                  title={block.title}
-                  style={{
-                    fontWeight: 600,
-                    fontSize: '16px',
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
-                    padding: '0 4px',
-                    color: '#1B2A4A',
-                  }}
+                <Tooltip
+                  label={block.title || 'Sem título'}
+                  hasArrow
+                  placement="top"
+                  isDisabled={!simplified}
                 >
-                  {block.title || 'Sem título'}
-                </div>
+                  <div
+                    title={block.title}
+                    style={{
+                      fontWeight: 600,
+                      fontSize: '16px',
+                      overflow: 'hidden',
+                      whiteSpace: 'nowrap',
+                      textOverflow: 'ellipsis',
+                      padding: '0 4px',
+                      color: '#1B2A4A',
+                    }}
+                  >
+                    {block.title || 'Sem título'}
+                  </div>
+                </Tooltip>
               ) : (
                 <Flex justifyContent="space-between" alignItems="center" gap="2">
                 <Editable
@@ -278,15 +289,30 @@ export const BlockNode = memo(({ block, blockIndex, simplified }: Props) => {
                 (simplified ? (
                   <Stack spacing="2">
                     {block.steps.map((step) => (
-                      <div
+                      <Tooltip
                         key={step.id}
-                        style={{
-                          backgroundColor: '#E2E8F0',
-                          borderRadius: '6px',
-                          width: '100%',
-                          height: '120px',
-                        }}
-                      />
+                        label={
+                          <Box>
+                            <StepTypeLabel type={step.type as StepType} />
+                          </Box>
+                        }
+                        hasArrow
+                        placement="bottom"
+                      >
+                        <div
+                          style={{
+                            backgroundColor: '#E2E8F0',
+                            borderRadius: '6px',
+                            width: '100%',
+                            height: '120px',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          <StepIcon type={step.type} fontSize="52px" />
+                        </div>
+                      </Tooltip>
                     ))}
                   </Stack>
                 ) : (

--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemDraggable/ItemDraggableList.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemDraggable/ItemDraggableList.tsx
@@ -18,7 +18,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { Box, HStack, IconButton, Stack, Flex, Icon } from '@chakra-ui/react';
 import { DragHandleIcon } from '@chakra-ui/icons';
 import { Item, ItemIndices, StepWithItems, Step, ChoiceInputStep } from 'models';
-import { useTypebot } from 'contexts/TypebotContext';
+import { useTypebotActions, useTypebotSelector } from 'contexts/TypebotContext';
 import { ItemNodeContent } from '../ItemNodeContent';
 import { SourceEndpoint } from '../../../Endpoints/SourceEndpoint';
 import { MdClose } from 'react-icons/md';
@@ -50,14 +50,13 @@ const SortableItem = ({
   onUpdateItem,
   renderItemContent,
 }: SortableItemProps) => {
-  const { typebot } = useTypebot();
-  
-  const isConnectable = !(
-    (typebot?.blocks?.[indices.blockIndex]?.steps?.[
-      indices.stepIndex
-    ] as ChoiceInputStep | undefined)
-  )?.options?.isMultipleChoice;
-  const showConnection = typebot && isConnectable && isReadOnly;
+  const liveStep = useTypebotSelector(
+    (t) => t?.blocks?.[indices.blockIndex]?.steps?.[indices.stepIndex]
+  );
+
+  const isConnectable = !(liveStep as ChoiceInputStep | undefined)?.options
+    ?.isMultipleChoice;
+  const showConnection = !!liveStep && isConnectable && isReadOnly;
 
   const {
     attributes,
@@ -136,7 +135,7 @@ const SortableItem = ({
                 {showConnection && (
                   <SourceEndpoint
                     source={{
-                      blockId: typebot.blocks[indices.blockIndex].id,
+                      blockId: liveStep?.blockId ?? '',
                       stepId: item.stepId,
                       itemId: item.id,
                     }}
@@ -198,7 +197,7 @@ export const ItemDraggableList = ({
   renderItemContent,
 }: ItemDraggableListProps) => {
   const { blockIndex, stepIndex } = indices;
-  const { reorderItem, deleteItem } = useTypebot();
+  const { reorderItem, deleteItem } = useTypebotActions();
 
   const sensors = useSensors(
     useSensor(PointerSensor, {

--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ButtonNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ButtonNodeContent.tsx
@@ -4,7 +4,7 @@ import {
   Editable,
   Flex,
 } from '@chakra-ui/react'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotActions } from 'contexts/TypebotContext'
 import { ButtonItem, ItemIndices, ItemType } from 'models'
 import React, { useEffect, useRef, useState } from 'react'
 
@@ -17,7 +17,7 @@ type Props = {
 export const ButtonNodeContent = ({ item, indices, onUpdateItem }: Props) => {
   const defaultPlaceholder = 'Insira o texto desta resposta...' 
 
-  const { deleteItem, updateItem, createItem } = useTypebot()
+  const { deleteItem, updateItem, createItem } = useTypebotActions()
   const [initialContent] = useState(item.content ?? '')
   const [itemValue, setItemValue] = useState(
     item.content ?? defaultPlaceholder

--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ConditionNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ConditionNodeContent.tsx
@@ -1,5 +1,5 @@
 import { Stack, Tag, Text, Flex, Wrap } from '@chakra-ui/react'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotExtras, useTypebotVariables } from 'contexts/TypebotContext'
 import {
   Comparison,
   ConditionItem,
@@ -17,7 +17,8 @@ type Props = {
 }
 
 export const ConditionNodeContent = ({ item }: Props) => {
-  const { typebot, customVariables } = useTypebot()
+  const variables = useTypebotVariables()
+  const { customVariables } = useTypebotExtras()
   const basicOptions = useContactStatus()
 
   const getComparisonValue = (
@@ -49,7 +50,7 @@ export const ConditionNodeContent = ({ item }: Props) => {
     return (
       <Stack maxW="170px">
         {item.content.comparisons.map((comparison, idx) => {
-          const variable = typebot?.variables.find(
+          const variable = variables?.find(
             byIdOrToken(comparison.variableId)
           )
           return (

--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/OfficeHoursNodeContent/OfficeHoursNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/OfficeHoursNodeContent/OfficeHoursNodeContent.tsx
@@ -1,5 +1,4 @@
 import { Stack, Tag, Text, Flex, Wrap } from '@chakra-ui/react'
-import { useTypebot } from 'contexts/TypebotContext'
 import {
   Comparison,
   ConditionItem,
@@ -14,8 +13,6 @@ type Props = {
 }
 
 export const OfficeHoursNodeContent = ({ item }: Props) => {
-  const { typebot } = useTypebot()
-
   return (
     <Container>
       {item.content.values.map((value, idx) => (

--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeList/ItemNodesList.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeList/ItemNodesList.tsx
@@ -16,7 +16,7 @@ import {
   computeNearestPlaceholderIndex,
   useStepDnd,
 } from 'contexts/GraphDndContext'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotActions, useTypebotSelector } from 'contexts/TypebotContext'
 import {
   ButtonItem,
   InputStepType,
@@ -52,17 +52,17 @@ export const ItemNodesList = ({
   indices: { blockIndex, stepIndex },
   isReadOnly = false,
 }: Props) => {
-  const { typebot, createItem } = useTypebot()
+  const { createItem } = useTypebotActions()
+  const block = useTypebotSelector((t) => t?.blocks[blockIndex])
   const { draggedItem, setDraggedItem, mouseOverBlock } = useStepDnd()
   const placeholderRefs = useRef<HTMLDivElement[]>([])
   const { getGraphPosition } = useGraph()
-  const blockId = typebot?.blocks[blockIndex].id
+  const blockId = block?.id
   const isDraggingOnCurrentBlock =
     (draggedItem && mouseOverBlock?.id === blockId) ?? false
   const showPlaceholders = draggedItem && !isReadOnly
 
-  const isLastStep =
-    typebot?.blocks[blockIndex].steps[stepIndex + 1] === undefined
+  const isLastStep = block?.steps[stepIndex + 1] === undefined
 
   const [position, setPosition] = useState({
     x: 0,
@@ -130,23 +130,23 @@ export const ItemNodesList = ({
     }
 
   const webhook = {
-    method: typebot?.blocks[blockIndex]?.steps[stepIndex]?.options?.method,
-    url: typebot?.blocks[blockIndex]?.steps[stepIndex]?.options?.url,
-    path: typebot?.blocks[blockIndex]?.steps[stepIndex]?.options?.path,
+    method: block?.steps[stepIndex]?.options?.method,
+    url: block?.steps[stepIndex]?.options?.url,
+    path: block?.steps[stepIndex]?.options?.path,
   }
 
   const chatReturn = {
-    time: typebot?.blocks[blockIndex]?.steps[stepIndex]?.options?.time,
-    timeType: typebot?.blocks[blockIndex]?.steps[stepIndex]?.options?.timeTypeValue
+    time: block?.steps[stepIndex]?.options?.time,
+    timeType: block?.steps[stepIndex]?.options?.timeTypeValue
       === TimeTypeValue.HOUR ? 'horas' : 'minutos',
-    validationError: typebot?.blocks[blockIndex]?.steps[stepIndex]?.options?.validationError
+    validationError: block?.steps[stepIndex]?.options?.validationError
   }
 
   const getWebhookDetails = () => {
     try {
       const headers = {}
 
-      typebot?.blocks[blockIndex]?.steps[stepIndex]?.options?.headers.map(
+      block?.steps[stepIndex]?.options?.headers.map(
         (header) => {
           headers[header.key] = header.value
         }
@@ -155,7 +155,7 @@ export const ItemNodesList = ({
       const jsonPreview = {
         headers,
         body: JSON.parse(
-          typebot?.blocks[blockIndex]?.steps[stepIndex]?.options?.body
+          block?.steps[stepIndex]?.options?.body
         ),
       }
 
@@ -178,14 +178,14 @@ export const ItemNodesList = ({
     >
       {step.type === OctaStepType.OFFICE_HOURS && (
         <Stack paddingBottom={'10px'}>
-          {!typebot?.blocks[blockIndex].steps[stepIndex]?.options?.name && (
+          {!block?.steps[stepIndex]?.options?.name && (
             <HandleSelectCalendar>Selecione o expediente:</HandleSelectCalendar>
           )}
-          {typebot?.blocks[blockIndex].steps[stepIndex]?.options?.name && (
+          {block?.steps[stepIndex]?.options?.name && (
             <div>
               Horário: &nbsp;&nbsp;
               <SelectedCalendar>
-                {typebot?.blocks[blockIndex].steps[stepIndex].options?.name}
+                {block?.steps[stepIndex].options?.name}
               </SelectedCalendar>
             </div>
           )}

--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeList/ItemNodesList.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeList/ItemNodesList.tsx
@@ -55,7 +55,7 @@ export const ItemNodesList = ({
   const { typebot, createItem } = useTypebot()
   const { draggedItem, setDraggedItem, mouseOverBlock } = useStepDnd()
   const placeholderRefs = useRef<HTMLDivElement[]>([])
-  const { graphPosition } = useGraph()
+  const { getGraphPosition } = useGraph()
   const blockId = typebot?.blocks[blockIndex].id
   const isDraggingOnCurrentBlock =
     (draggedItem && mouseOverBlock?.id === blockId) ?? false
@@ -314,7 +314,7 @@ export const ItemNodesList = ({
             top="0"
             left="0"
             style={{
-              transform: `translate(${position.x}px, ${position.y}px) rotate(-2deg) scale(${graphPosition.scale})`,
+              transform: `translate(${position.x}px, ${position.y}px) rotate(-2deg) scale(${getGraphPosition().scale})`,
             }}
             transformOrigin="0 0 0"
           />

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/SettingsModal.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/SettingsModal.tsx
@@ -21,12 +21,14 @@ import { useIframeOverlayEvent } from 'hooks/useIframeOverlayEvent'
 type Props = {
   isOpen: boolean
   onClose: () => void
+  onCloseComplete?: () => void
   stepType: StepType
 }
 
 export const SettingsModal = ({
   isOpen,
   onClose,
+  onCloseComplete,
   stepType,
   ...props
 }: Props & ModalBodyProps) => {
@@ -40,6 +42,7 @@ export const SettingsModal = ({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
+      onCloseComplete={onCloseComplete}
       size={stepType === WOZStepType.MESSAGE ? 'full' : 'xl'}
     >
       <ModalOverlay />

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/ChoiceInputSettingsBody.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/SettingsPopoverContent/bodies/ChoiceInputSettingsBody.tsx
@@ -168,7 +168,7 @@ export const ChoiceInputSettingsBody = ({
                 {isCollapsed ? <SlArrowDown /> : <SlArrowUp />}
               </Button>
             </Flex>
-            <Collapse in={isCollapsed}>
+            <Collapse in={isCollapsed} unmountOnExit>
               <Flex direction={'column'} gap={4}>
                 {options?.fallbackMessages.map((message, index) =>
                   fallbackMessageComponent(message, index)

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -49,7 +49,7 @@ import {
   WhatsAppOptionsListStep,
 } from 'models'
 import { useRouter } from 'next/router'
-import React, { createContext, useEffect, useRef, useState } from 'react'
+import React, { createContext, memo, useEffect, useRef, useState } from 'react'
 import { useIframeOverlayEvent } from 'hooks/useIframeOverlayEvent'
 import { hasDefaultConnector } from 'services/typebots'
 import { setMultipleRefs } from 'services/utils'
@@ -76,7 +76,7 @@ type StepNodeContextProps = {
 
 export const StepNodeContext = createContext<StepNodeContextProps>({})
 
-export const StepNode = ({
+const StepNodeBase = ({
   step,
   isConnectable,
   indices,
@@ -450,6 +450,17 @@ export const StepNode = ({
     </StepNodeContext.Provider>
   )
 }
+
+export const StepNode = memo(
+  StepNodeBase,
+  (prev, next) =>
+    prev.step === next.step &&
+    prev.isConnectable === next.isConnectable &&
+    prev.unreachableNode === next.unreachableNode &&
+    prev.indices.blockIndex === next.indices.blockIndex &&
+    prev.indices.stepIndex === next.indices.stepIndex &&
+    prev.onMouseDown === next.onMouseDown
+)
 
 const isEndConversationStep = (
   step: Step

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -133,10 +133,16 @@ const StepNodeBase = ({
   })
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
+  const [modalMounted, setModalMounted] = useState<boolean>(false)
   const beforeCloseRef = useRef<(() => boolean) | null>(null)
 
   const registerBeforeClose = (handler: (() => boolean) | null) => {
     beforeCloseRef.current = handler
+  }
+
+  const handleSetIsModalOpen = (open: boolean) => {
+    if (open) setModalMounted(true)
+    setIsModalOpen(open)
   }
 
   const [validationMessages, setValidationMessages] =
@@ -192,13 +198,14 @@ const StepNodeBase = ({
     if (beforeCloseRef.current?.()) return
 
     updateStep(indices, { ...step })
-    
+
     refreshConnections(step)
-    
+
     onModalClose()
     setIsModalOpen(false)
     setIsEditing(false)
     setIsPopoverOpened(false)
+    // modalMounted is cleared by onCloseComplete after exit animation
   }
 
   const handleKeyUp = (content: TextBubbleContent) => {
@@ -208,7 +215,7 @@ const StepNodeBase = ({
 
   const handleCloseEditor = () => {
     setIsEditing(false)
-    setIsModalOpen(false)
+    handleSetIsModalOpen(false)
     setIsPopoverOpened(false)
   }
 
@@ -217,11 +224,11 @@ const StepNodeBase = ({
     e.stopPropagation()
 
     if (step.type === OctaBubbleStepType.END_CONVERSATION) {
-      setIsModalOpen(true)
+      handleSetIsModalOpen(true)
     } else if (isOctaBubbleStep(step)) {
       setIsEditing(true)
     } else if (!isWozSuggestionStep(step)) {
-      setIsModalOpen(true)
+      handleSetIsModalOpen(true)
     }
 
     setOpenedStepId(step.id)
@@ -267,7 +274,7 @@ const StepNodeBase = ({
       menuPosition="absolute"
     />
   ) : (
-    <StepNodeContext.Provider value={{ setIsPopoverOpened, setIsModalOpen, registerBeforeClose }}>
+    <StepNodeContext.Provider value={{ setIsPopoverOpened, setIsModalOpen: handleSetIsModalOpen, registerBeforeClose }}>
       <ContextMenu<HTMLDivElement>
         renderMenu={() => <StepNodeContextMenu indices={indices} />}
       >
@@ -432,18 +439,21 @@ const StepNodeBase = ({
                 </Stack>
               </Flex>
             </PopoverTrigger>
-            <SettingsModal
-              id="settings-modal"
-              isOpen={isModalOpen}
-              onClose={handleModalClose}
-              stepType={step.type}
-            >
-              <StepSettings
-                step={step}
-                indices={indices}
-                onStepChange={handleStepUpdate}
-              />
-            </SettingsModal>
+            {modalMounted && (
+              <SettingsModal
+                id="settings-modal"
+                isOpen={isModalOpen}
+                onClose={handleModalClose}
+                onCloseComplete={() => setModalMounted(false)}
+                stepType={step.type}
+              >
+                <StepSettings
+                  step={step}
+                  indices={indices}
+                  onStepChange={handleStepUpdate}
+                />
+              </SettingsModal>
+            )}
           </Popover>
         )}
       </ContextMenu>

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -16,7 +16,13 @@ import OctaTooltip from 'components/octaComponents/OctaTooltip/OctaTooltip'
 import { ContextMenu } from 'components/shared/ContextMenu'
 import { useGraph } from 'contexts/GraphContext'
 import { NodePosition, useDragDistance } from 'contexts/GraphDndContext'
-import { useTypebot } from 'contexts/TypebotContext'
+import {
+  useGetEmptyFields,
+  useTypebotActions,
+  useTypebotAvailableFor,
+  useTypebotEdges,
+  useTypebotExtras,
+} from 'contexts/TypebotContext'
 import { ActionsTypeEmptyFields } from 'hooks/EmptyFields/useEmptyFields'
 import { useRefreshGraphConnections } from 'hooks/useRefreshGraphConnections'
 import { colors } from 'libs/theme'
@@ -92,12 +98,16 @@ export const StepNode = ({
     setFocusedBlockId,
     previewingEdge,
   } = useGraph()
-  const { updateStep, emptyFields, setEmptyFields, typebot } = useTypebot()
+  const { updateStep } = useTypebotActions()
+  const { setEmptyFields } = useTypebotExtras()
+  const getEmptyFields = useGetEmptyFields()
+  const availableFor = useTypebotAvailableFor()
+  const edges = useTypebotEdges()
   const { refreshConnections, cleanup } = useRefreshGraphConnections()
   const [isConnecting, setIsConnecting] = useState(false)
 
   const availableOnlyForEvent =
-    typebot?.availableFor?.length == 1 && typebot.availableFor.includes('event')
+    availableFor?.length == 1 && availableFor.includes('event')
 
   const showWarning = !availableOnlyForEvent
 
@@ -132,11 +142,12 @@ export const StepNode = ({
   const [validationMessages, setValidationMessages] =
     useState<Array<ValidationMessage>>()
 
-  const edgesLength = typebot?.edges?.length ?? 0
+  const edgesLength = edges?.length ?? 0
 
   useEffect(() => {
-    const currentMessages = getValidationMessages(step, typebot?.edges)
+    const currentMessages = getValidationMessages(step, edges)
     setValidationMessages(currentMessages)
+    const emptyFields = getEmptyFields()
     if (currentMessages.length > 0) {
       if (!emptyFields.find((field) => field?.step.id === step?.id)) {
         setEmptyFields(
@@ -150,7 +161,8 @@ export const StepNode = ({
         setEmptyFields([step?.id], ActionsTypeEmptyFields.REMOVE)
       }
     }
-  }, [step, edgesLength, typebot?.edges])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, edgesLength, edges])
 
   const { onClose: onModalClose } = useDisclosure({
     defaultIsOpen: true,

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -206,7 +206,6 @@ const StepNodeBase = ({
     setIsModalOpen(false)
     setIsEditing(false)
     setIsPopoverOpened(false)
-    // modalMounted is cleared by onCloseComplete after exit animation
   }
 
   const handleKeyUp = (content: TextBubbleContent) => {

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/StepNodeContent/StepNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/StepNodeContent/StepNodeContent.tsx
@@ -28,7 +28,7 @@ import { WhatsAppButtonsContent } from '../contents/WhatsApp/WhatsAppButtons'
 import { WhatsAppOptionsContent } from '../contents/WhatsApp/WhatsAppOptions'
 // import { PaymentInputContent } from './contents/PaymentInputContent'
 // import { SendEmailContent } from './contents/SendEmailContent'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotActions } from 'contexts/TypebotContext'
 import { ConversationTagContent } from '../contents/ConversationTag'
 import { InputContent } from '../contents/Input'
 import { InputItemsContent } from '../contents/InputItemsContent'
@@ -44,7 +44,7 @@ type Props = {
   indices: StepIndices
 }
 export const StepNodeContent = ({ step, indices }: Props) => {
-  const { updateStep } = useTypebot()
+  const { updateStep } = useTypebotActions()
   const handleStepUpdate = (options: StepOptions): void => {
     const stepWithOptions = step as StepWithOptions
     if (stepWithOptions.options) {

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/AssignToTeam/AssignToTeamContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/AssignToTeam/AssignToTeamContent.tsx
@@ -5,7 +5,11 @@ import { SourceEndpoint } from '../../../../../Endpoints'
 import { TableListOcta } from 'components/shared/TableListOcta'
 import { OctaDivider } from 'components/octaComponents/OctaDivider/OctaDivider'
 import { ASSIGN_TO } from 'enums/assign-to'
-import { useTypebot } from 'contexts/TypebotContext'
+import {
+  useGetTypebot,
+  useTypebotEdges,
+  useTypebotExtras,
+} from 'contexts/TypebotContext'
 import { parseVariableHighlight } from 'services/utils'
 import { TextHtmlContent } from '../TextHtmlContent'
 import { hasAnyChatReturnInItsTree } from './hasAnyChatReturnInItsTree'
@@ -20,16 +24,21 @@ type Props = {
 export const AssignToTeamContent = ({
   step, onUpdateStep
 }: Props) => {
-  const { octaAgents, typebot } = useTypebot();
+  const { octaAgents } = useTypebotExtras();
+  const getTypebot = useGetTypebot()
+  const edges = useTypebotEdges()
   const { verifyFeatureToggle } = useUser()
 
   React.useEffect(() => {
     if (
-      !verifyFeatureToggle('customer-recontact') 
+      !verifyFeatureToggle('customer-recontact')
       || typeof onUpdateStep !== 'function'
     ) return
-    
-    const showChatReturnOption = hasAnyChatReturnInItsTree(typebot, step.blockId)
+
+    const showChatReturnOption = hasAnyChatReturnInItsTree(
+      getTypebot(),
+      step.blockId
+    )
     let options = {} as AssignToTeamOptions
     if (!showChatReturnOption && step.options?.assignType === '@CHAT-RETURN') {
       options.assignTo = ''
@@ -39,7 +48,8 @@ export const AssignToTeamContent = ({
     onUpdateStep({
       ...step.options, ... options, showChatReturnOption
     })
-  }, [typebot?.edges])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [edges])
 
   const resolveAssignTo = (assignTo: string) => {
     const value = octaAgents.find(s => s.id === assignTo)

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/CallOtherBot/CallOtherBotContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/CallOtherBot/CallOtherBotContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { CallOtherBotOptions, CallOtherBotStep } from 'models'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotExtras } from 'contexts/TypebotContext'
 import { Stack, Text, chakra } from '@chakra-ui/react'
 
 type Props = {
@@ -9,7 +9,7 @@ type Props = {
 }
 
 export const CallOtherBotContent = ({ options }: Props) => {
-  const { botFluxesList } = useTypebot()
+  const { botFluxesList } = useTypebotExtras()
   const selectedBot = botFluxesList?.filter((item) => item.id === options)[0]
 
   return (

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/Input/InputContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/Input/InputContent.tsx
@@ -2,7 +2,7 @@ import { InputOptions, Variable } from 'models'
 import React, { useEffect } from 'react'
 import { Stack } from '@chakra-ui/react'
 import { WithVariableContent } from '../WithVariableContent'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotVariables } from 'contexts/TypebotContext'
 import { OctaDivider } from 'components/octaComponents/OctaDivider/OctaDivider'
 import { useWorkspace } from 'contexts/WorkspaceContext'
 import { TextHtmlContent } from '../TextHtmlContent'
@@ -16,7 +16,7 @@ type Props = {
 }
 
 const InputContent = ({ step, onUpdateStep }: Props) => {
-  const { typebot } = useTypebot()
+  const variables = useTypebotVariables()
   const { createCustomField } = useWorkspace()
 
   const handleDefaultTokenNotFound = async () => {
@@ -28,7 +28,7 @@ const InputContent = ({ step, onUpdateStep }: Props) => {
         const name = splitedToken.join('-').replace(/#/g, '')
 
         if (domain) {
-          const domainVariables = typebot?.variables?.filter(v => v.domain === domain)
+          const domainVariables = variables?.filter(v => v.domain === domain)
 
           if (domainVariables) {
             const domainProperty = domainVariables.find(
@@ -57,7 +57,7 @@ const InputContent = ({ step, onUpdateStep }: Props) => {
 
   useEffect(() => {
     if (!step.options.variableId && step.options.initialVariableToken) {
-      let myVariable = typebot?.variables?.find(v => v.token === step.options.initialVariableToken)
+      let myVariable = variables?.find(v => v.token === step.options.initialVariableToken)
       if (myVariable) {
         step.options.variableId = myVariable.id
         handleVariableChange(myVariable)
@@ -65,12 +65,12 @@ const InputContent = ({ step, onUpdateStep }: Props) => {
         handleDefaultTokenNotFound()
       }
     }
-  }, [typebot?.variables])
+  }, [variables])
 
 
 
   if (!step.options.variableId && step.options.initialVariableToken) {
-    let myVariable = typebot?.variables?.find(v => v.token === step.options.initialVariableToken)
+    let myVariable = variables?.find(v => v.token === step.options.initialVariableToken)
     if (myVariable) {
       step.options.variableId = myVariable.id
       handleVariableChange(myVariable)

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/PreReserve/PreReserveContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/PreReserve/PreReserveContent.tsx
@@ -1,4 +1,4 @@
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotExtras } from 'contexts/TypebotContext'
 import { Options } from 'got'
 import { PreReserveStep } from 'models'
 import React, { useEffect, useState } from 'react'
@@ -11,7 +11,7 @@ type Props = {
 }
 
 const PreReserveContent = ({ step }: Props) => {
-  const { octaGroups } = useTypebot();
+  const { octaGroups } = useTypebotExtras();
 
   const [selectedGroup, setSelectedGroup] = useState<any>();
 

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TextBubbleContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TextBubbleContent.tsx
@@ -3,8 +3,7 @@ import { useTypebotVariables } from 'contexts/TypebotContext'
 import { EndConversationStep, TextBubbleStep, Typebot } from 'models'
 import React from 'react'
 import { parseVariableHighlight } from 'services/utils'
-import DOMPurify from 'dompurify'
-import { textBubbleEditorContentConfig } from 'config/dompurify'
+import { sanitizeBubbleHtml } from 'services/sanitizeHtml'
 
 type Props = {
   step: TextBubbleStep | EndConversationStep
@@ -12,10 +11,7 @@ type Props = {
 
 export const TextBubbleContent = ({ step }: Props) => {
   const variables = useTypebotVariables()
-  const sanitizedHtml = DOMPurify.sanitize(
-    step.content.html,
-    textBubbleEditorContentConfig
-  )
+  const sanitizedHtml = sanitizeBubbleHtml(step.content.html)
 
   if (!variables) return <></>
   return (

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TextBubbleContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TextBubbleContent.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@chakra-ui/react'
-import { useTypebot } from 'contexts/TypebotContext'
-import { EndConversationStep, TextBubbleStep } from 'models'
+import { useTypebotVariables } from 'contexts/TypebotContext'
+import { EndConversationStep, TextBubbleStep, Typebot } from 'models'
 import React from 'react'
 import { parseVariableHighlight } from 'services/utils'
 import DOMPurify from 'dompurify'
@@ -11,13 +11,13 @@ type Props = {
 }
 
 export const TextBubbleContent = ({ step }: Props) => {
-  const { typebot } = useTypebot()
+  const variables = useTypebotVariables()
   const sanitizedHtml = DOMPurify.sanitize(
     step.content.html,
     textBubbleEditorContentConfig
   )
 
-  if (!typebot) return <></>
+  if (!variables) return <></>
   return (
     <Flex
       w="90%"
@@ -25,10 +25,9 @@ export const TextBubbleContent = ({ step }: Props) => {
       opacity={step.content.html ? '1' : '0.5'}
       className="slate-html-container"
       dangerouslySetInnerHTML={{
-        __html:
-          sanitizedHtml
-            ? parseVariableHighlight(sanitizedHtml, typebot)
-            : `<p>Clique para editar...</p>`,
+        __html: sanitizedHtml
+          ? parseVariableHighlight(sanitizedHtml, { variables } as Typebot)
+          : `<p>Clique para editar...</p>`,
       }}
     />
   )

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TextHtmlContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TextHtmlContent.tsx
@@ -1,6 +1,7 @@
 import { Flex } from '@chakra-ui/react'
 import { textBubbleEditorContentConfig } from 'config/dompurify'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotVariables } from 'contexts/TypebotContext'
+import { Typebot } from 'models'
 import DOMPurify from 'dompurify'
 import { parseVariableHighlight } from 'services/utils'
 
@@ -21,7 +22,7 @@ export const TextHtmlContent = ({
   fontWeight,
   color,
 }: Props) => {
-  const { typebot } = useTypebot()
+  const variables = useTypebotVariables()
   const sanitizedHtml = DOMPurify.sanitize(html, textBubbleEditorContentConfig)
 
   return !renderIfEmpty && !sanitizedHtml ? (
@@ -34,8 +35,8 @@ export const TextHtmlContent = ({
       className="slate-html-container"
       dangerouslySetInnerHTML={{
         __html:
-          sanitizedHtml && typebot
-            ? parseVariableHighlight(sanitizedHtml, typebot)
+          sanitizedHtml && variables
+            ? parseVariableHighlight(sanitizedHtml, { variables } as Typebot)
             : `<p>${defaultPlaceholder || 'Configurar...'}</p>`,
       }}
       fontSize={fontSize}

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TextHtmlContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TextHtmlContent.tsx
@@ -1,9 +1,8 @@
 import { Flex } from '@chakra-ui/react'
-import { textBubbleEditorContentConfig } from 'config/dompurify'
 import { useTypebotVariables } from 'contexts/TypebotContext'
 import { Typebot } from 'models'
-import DOMPurify from 'dompurify'
 import { parseVariableHighlight } from 'services/utils'
+import { sanitizeBubbleHtml } from 'services/sanitizeHtml'
 
 type Props = {
   html?: string
@@ -23,7 +22,7 @@ export const TextHtmlContent = ({
   color,
 }: Props) => {
   const variables = useTypebotVariables()
-  const sanitizedHtml = DOMPurify.sanitize(html, textBubbleEditorContentConfig)
+  const sanitizedHtml = sanitizeBubbleHtml(html)
 
   return !renderIfEmpty && !sanitizedHtml ? (
     <></>

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TypebotLinkContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/TypebotLinkContent.tsx
@@ -1,7 +1,10 @@
 import { TypebotLinkStep } from 'models'
 import React from 'react'
 import { Tag, Text } from '@chakra-ui/react'
-import { useTypebot } from 'contexts/TypebotContext'
+import {
+  useTypebotExtras,
+  useTypebotSelector,
+} from 'contexts/TypebotContext'
 import { byId } from 'utils'
 
 type Props = {
@@ -9,15 +12,18 @@ type Props = {
 }
 
 export const TypebotLinkContent = ({ step }: Props) => {
-  const { linkedTypebots, typebot } = useTypebot()
+  const { linkedTypebots } = useTypebotExtras()
+  const typebotId = useTypebotSelector((t) => t?.id)
+  const typebotName = useTypebotSelector((t) => t?.name)
+  const currentBlocks = useTypebotSelector((t) => t?.blocks)
   const isCurrentTypebot =
-    typebot &&
-    (step.options.typebotId === typebot.id ||
+    !!typebotId &&
+    (step.options.typebotId === typebotId ||
       step.options.typebotId === 'current')
   const linkedTypebot = isCurrentTypebot
-    ? typebot
+    ? { blocks: currentBlocks, name: typebotName }
     : linkedTypebots?.find(byId(step.options.typebotId))
-  const blockTitle = linkedTypebot?.blocks.find(
+  const blockTitle = linkedTypebot?.blocks?.find(
     byId(step.options.blockId)
   )?.title
   if (!step.options.typebotId) return <Text color="gray.500">Configuração...</Text>

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WOZAssign/WOZAssignContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WOZAssign/WOZAssignContent.tsx
@@ -3,7 +3,7 @@ import React, { Fragment } from 'react'
 import { Stack, Text } from '@chakra-ui/react'
 import { ItemNodesList } from 'components/shared/Graph/Nodes/ItemNode'
 import { OctaDivider } from 'components/octaComponents/OctaDivider/OctaDivider'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotExtras } from 'contexts/TypebotContext'
 
 type Props = {
   step: WOZAssignStep
@@ -11,9 +11,9 @@ type Props = {
 }
 
 const WOZAssignContent = ({ step, indices }: Props) => {
-  const { wozProfiles } = useTypebot()
+  const { wozProfiles } = useTypebotExtras()
 
-  const agent = wozProfiles.find((d) => d.id === step?.options?.virtualAgentId)
+  const agent = wozProfiles?.find((d) => d.id === step?.options?.virtualAgentId)
 
   const agentName = () => {
     if (!agent?.name) return 'Woz'

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WhatsApp/WhatsAppButtons/WhatsAppButtonsContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WhatsApp/WhatsAppButtons/WhatsAppButtonsContent.tsx
@@ -10,7 +10,7 @@ import { ItemNodesList } from 'components/shared/Graph/Nodes/ItemNode'
 import { OctaDivider } from 'components/octaComponents/OctaDivider/OctaDivider'
 import { WithVariableContent } from '../../WithVariableContent'
 import { TextHtmlContent } from '../../TextHtmlContent'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotActions } from 'contexts/TypebotContext'
 import cuid from 'cuid'
 
 type Props = {
@@ -19,7 +19,7 @@ type Props = {
 }
 
 const WhatsApButtonsContent = ({ step, indices }: Props) => {
-  const { updateStep } = useTypebot()
+  const { updateStep } = useTypebotActions()
 
   if (!step.options) step.options = defaultWhatsAppButtonsListOptions
 

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WhatsApp/WhatsAppOptions/WhatsAppOptionsContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WhatsApp/WhatsAppOptions/WhatsAppOptionsContent.tsx
@@ -10,7 +10,7 @@ import { Stack, Text } from '@chakra-ui/react'
 import { WithVariableContent } from '../../WithVariableContent'
 import { OctaDivider } from 'components/octaComponents/OctaDivider/OctaDivider'
 import { TextHtmlContent } from '../../TextHtmlContent'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotActions } from 'contexts/TypebotContext'
 import cuid from 'cuid'
 
 type Props = {
@@ -19,7 +19,7 @@ type Props = {
 }
 
 const WhatsAppOptionsContent = ({ step, indices }: Props) => {
-  const { updateStep } = useTypebot()
+  const { updateStep } = useTypebotActions()
 
   if (!step.options) step.options = defaultWhatsAppOptionsListOptions
 

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WithVariableContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/contents/WithVariableContent.tsx
@@ -1,6 +1,6 @@
 import { chakra, Flex, Text } from '@chakra-ui/react'
 import React, { useEffect, useState } from 'react'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useTypebotVariables } from 'contexts/TypebotContext'
 import { OctaProperty, Variable } from 'models'
 import { useWorkspace } from 'contexts/WorkspaceContext'
 
@@ -10,7 +10,7 @@ type Props = {
 }
 
 export const WithVariableContent = ({ variableId, property }: Props) => {
-  const { typebot } = useTypebot()
+  const variables = useTypebotVariables()
   const { createChatField } = useWorkspace()
 
   const [variableName, setVariableName] = useState<string>('')
@@ -23,8 +23,8 @@ export const WithVariableContent = ({ variableId, property }: Props) => {
       return
     }
 
-    if (typebot?.variables) {
-      const variable = typebot.variables.find(
+    if (variables) {
+      const variable = variables.find(
         (v) => v.variableId === variableId || v.id === variableId || v.token === variableId
       )
 
@@ -39,7 +39,7 @@ export const WithVariableContent = ({ variableId, property }: Props) => {
     } else {
       setVariableName('')
     }
-  }, [typebot?.variables, variableId, property])
+  }, [variables, variableId, property])
 
   if (!variableName || variableName.trim() === '') {
     return null

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
@@ -13,7 +13,7 @@ import {
   computeNearestPlaceholderIndex,
   useStepDnd,
 } from 'contexts/GraphDndContext'
-import { useTypebot } from 'contexts/TypebotContext'
+import { useHasTypebot, useTypebotActions } from 'contexts/TypebotContext'
 import {
   DraggableStep,
   DraggableStepType,
@@ -52,7 +52,8 @@ export const StepNodesList = ({
     mouseOverBlock,
     setDraggedStepType,
   } = useStepDnd()
-  const { typebot, createStep, detachStepFromBlock } = useTypebot()
+  const { createStep, detachStepFromBlock } = useTypebotActions()
+  const hasTypebot = useHasTypebot()
   const { isReadOnly, getGraphPosition } = useGraph()
   const [expandedPlaceholderIndex, setExpandedPlaceholderIndex] = useState<
     number | undefined
@@ -194,7 +195,7 @@ export const StepNodesList = ({
           </HStack>
         </Center>
       </Flex>
-      {typebot &&
+      {hasTypebot &&
         steps.map((step, idx) => (
           <Fragment key={step.id}>
             <StepNode

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
@@ -53,7 +53,7 @@ export const StepNodesList = ({
     setDraggedStepType,
   } = useStepDnd()
   const { typebot, createStep, detachStepFromBlock } = useTypebot()
-  const { isReadOnly, graphPosition } = useGraph()
+  const { isReadOnly, getGraphPosition } = useGraph()
   const [expandedPlaceholderIndex, setExpandedPlaceholderIndex] = useState<
     number | undefined
   >()
@@ -240,7 +240,7 @@ export const StepNodesList = ({
             top="0"
             left="0"
             style={{
-              transform: `translate(${position.x}px, ${position.y}px) rotate(-2deg) scale(${graphPosition.scale})`,
+              transform: `translate(${position.x}px, ${position.y}px) rotate(-2deg) scale(${getGraphPosition().scale})`,
             }}
             transformOrigin="0 0 0"
           />

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
@@ -27,7 +27,7 @@ import {
   StepType,
   WOZStepType,
 } from 'models'
-import { Fragment, useEffect, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { StepNode } from './StepNode/StepNode'
 import { StepNodeOverlay } from './StepNodeOverlay'
 
@@ -138,7 +138,7 @@ export const StepNodesList = ({
     setHasBlockEndedIndex(endedIndex)
   }, [steps])
 
-  const handleStepMouseDown =
+  const handleStepMouseDown = useCallback(
     (stepIndex: number) =>
       (
         { absolute, relative }: { absolute: Coordinates; relative: Coordinates },
@@ -150,7 +150,27 @@ export const StepNodesList = ({
         setPosition(absolute)
         setMousePositionInElement(relative)
         setDraggedStep(step)
-      }
+      },
+    // setDraggedStep é um setter estável do useState; incluso para satisfazer o linter.
+    // setPosition e setMousePositionInElement também são setters estáveis, omitidos
+    // pois não afetam a identidade da função entre renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isReadOnly, detachStepFromBlock, blockIndex, setDraggedStep]
+  )
+
+  // Dep intencional: só recria quando steps são adicionados/removidos (length),
+  // não quando o conteúdo de um step muda — evitaria o ganho do memo em StepNode.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stableIndices = useMemo(
+    () => steps.map((_, idx) => ({ blockIndex, stepIndex: idx })),
+    [blockIndex, steps.length]
+  )
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stableOnMouseDown = useMemo(
+    () => steps.map((_, idx) => handleStepMouseDown(idx)),
+    [handleStepMouseDown, steps.length]
+  )
 
   const handlePushElementRef =
     (idx: number) => (elem: HTMLDivElement | null) => {
@@ -200,9 +220,9 @@ export const StepNodesList = ({
           <Fragment key={step.id}>
             <StepNode
               step={step}
-              indices={{ blockIndex, stepIndex: idx }}
+              indices={stableIndices[idx]}
               isConnectable={steps.length - 1 === idx}
-              onMouseDown={handleStepMouseDown(idx)}
+              onMouseDown={stableOnMouseDown[idx]}
               isStartBlock={isStartBlock}
               unreachableNode={blockEndedIndex >= 0 && blockEndedIndex < idx}
             />

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
@@ -151,15 +151,10 @@ export const StepNodesList = ({
         setMousePositionInElement(relative)
         setDraggedStep(step)
       },
-    // setDraggedStep é um setter estável do useState; incluso para satisfazer o linter.
-    // setPosition e setMousePositionInElement também são setters estáveis, omitidos
-    // pois não afetam a identidade da função entre renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [isReadOnly, detachStepFromBlock, blockIndex, setDraggedStep]
   )
 
-  // Dep intencional: só recria quando steps são adicionados/removidos (length),
-  // não quando o conteúdo de um step muda — evitaria o ganho do memo em StepNode.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const stableIndices = useMemo(
     () => steps.map((_, idx) => ({ blockIndex, stepIndex: idx })),

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/TextBubbleEditor/TextBubbleEditor.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/TextBubbleEditor/TextBubbleEditor.tsx
@@ -62,6 +62,8 @@ export const TextBubbleEditor = ({
 
   const currentValueRef = useRef<TElement[]>(initialValueRef.current)
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const truncationTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const truncationRafRef = useRef<number | null>(null)
   const hasShownLimitMessage = useRef(false)
 
   const editorId = useRef(
@@ -96,9 +98,9 @@ export const TextBubbleEditor = ({
 
   useEffect(() => {
     return () => {
-      if (debounceTimerRef.current) {
-        clearTimeout(debounceTimerRef.current)
-      }
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
+      if (truncationTimerRef.current) clearTimeout(truncationTimerRef.current)
+      if (truncationRafRef.current) cancelAnimationFrame(truncationRafRef.current)
     }
   }, [])
 
@@ -175,7 +177,9 @@ export const TextBubbleEditor = ({
       if (plainText.length > maxLength) {
         const truncatedText = plainText.slice(0, maxLength)
 
-        setTimeout(() => {
+        if (truncationTimerRef.current) clearTimeout(truncationTimerRef.current)
+        truncationTimerRef.current = setTimeout(() => {
+          truncationTimerRef.current = null
           try {
             const truncatedValue: TElement[] = [
               {
@@ -203,7 +207,9 @@ export const TextBubbleEditor = ({
               onKeyUp(truncatedContent)
             }
 
-            requestAnimationFrame(() => {
+            if (truncationRafRef.current) cancelAnimationFrame(truncationRafRef.current)
+            truncationRafRef.current = requestAnimationFrame(() => {
+              truncationRafRef.current = null
               try {
                 const textLength = Node.string(editor.children[0]).length
                 Transforms.select(editor as BaseEditor, {

--- a/apps/builder/contexts/GraphContext.tsx
+++ b/apps/builder/contexts/GraphContext.tsx
@@ -64,15 +64,6 @@ export type BlocksCoordinates = IdMap<Coordinates>
 
 type CoordinatesListener = () => void
 
-/**
- * Store externo das coordenadas dos blocos.
- *
- * Mantém as coordenadas fora do `value` do React context para que arrastar um
- * bloco não recrie o context e re-renderize TODOS os consumidores. Cada
- * componente assina via `useSyncExternalStore` e só re-renderiza quando a fatia
- * que ele lê muda de identidade (a coordenada do seu próprio bloco, ou o objeto
- * inteiro para quem precisa de todas).
- */
 export class CoordinatesStore {
   private coordinates: BlocksCoordinates = {}
   private listeners = new Set<CoordinatesListener>()
@@ -128,12 +119,6 @@ export class CoordinatesStore {
   }
 }
 
-/**
- * Context isolado para a posição do grafo (pan/zoom). Separado do `graphContext`
- * para que mudanças de pan/zoom NÃO recriem o value do context principal e
- * re-renderizem todos os consumidores. Quem só precisa do `scale` em handlers
- * de drag deve usar `getGraphPosition()` (leitura imperativa, sem assinatura).
- */
 const graphPositionContext = createContext<{
   graphPosition: Position
   setGraphPosition: Dispatch<SetStateAction<Position>>
@@ -168,7 +153,7 @@ const graphContext = createContext<{
   coordinatesStore: CoordinatesStore
   getBlockCoordinates: (blockId?: string) => Coordinates | undefined
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore — default value intencional incompleto; o contexto só é consumido dentro de GraphProvider
+// @ts-ignore
 }>({
   connectingIds: null,
 })
@@ -183,7 +168,6 @@ export const GraphProvider = ({
   isReadOnly?: boolean
 }) => {
   const [graphPosition, setGraphPosition] = useState(graphPositionDefaultValue)
-  // Espelho síncrono da posição para leitura imperativa (sem assinatura).
   const graphPositionRef = useRef(graphPosition)
   graphPositionRef.current = graphPosition
   const getGraphPosition = useCallback(() => graphPositionRef.current, [])
@@ -354,10 +338,6 @@ export const useGraph = () => useContext(graphContext)
 
 export const useGraphPosition = () => useContext(graphPositionContext)
 
-/**
- * Assina a coordenada de UM bloco. O componente só re-renderiza quando a
- * coordenada desse bloco muda — arrastar outro bloco não o afeta.
- */
 export const useBlockCoordinates = (blockId?: string) => {
   const { coordinatesStore } = useContext(graphContext)
   const getSnapshot = useCallback(
@@ -371,10 +351,6 @@ export const useBlockCoordinates = (blockId?: string) => {
   )
 }
 
-/**
- * Assina o mapa completo de coordenadas. Use apenas onde realmente é preciso
- * conhecer todas (ex.: cálculo de visibilidade). Re-renderiza a cada mudança.
- */
 export const useAllBlocksCoordinates = (): BlocksCoordinates => {
   const { coordinatesStore } = useContext(graphContext)
   return useSyncExternalStore(
@@ -384,10 +360,6 @@ export const useAllBlocksCoordinates = (): BlocksCoordinates => {
   )
 }
 
-/**
- * Booleano que vira `true` quando as coordenadas iniciais foram carregadas.
- * Estável: só dispara re-render na transição false → true.
- */
 export const useCoordinatesReady = (): boolean => {
   const { coordinatesStore } = useContext(graphContext)
   return useSyncExternalStore(

--- a/apps/builder/contexts/GraphContext.tsx
+++ b/apps/builder/contexts/GraphContext.tsx
@@ -145,8 +145,10 @@ const graphContext = createContext<{
   setPreviewingEdge: Dispatch<SetStateAction<Edge | undefined>>
   sourceEndpoints: IdMap<Endpoint>
   addSourceEndpoint: (endpoint: Endpoint) => void
+  removeSourceEndpoint: (id: string) => void
   targetEndpoints: IdMap<Endpoint>
   addTargetEndpoint: (endpoint: Endpoint) => void
+  removeTargetEndpoint: (id: string) => void
   openedStepId?: string
   setOpenedStepId: Dispatch<SetStateAction<string | undefined>>
   isReadOnly: boolean
@@ -158,6 +160,8 @@ const graphContext = createContext<{
   //@ts-ignore
   coordinatesStore: CoordinatesStore
   getBlockCoordinates: (blockId?: string) => Coordinates | undefined
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — default value intencional incompleto; o contexto só é consumido dentro de GraphProvider
 }>({
   connectingIds: null,
 })
@@ -205,11 +209,27 @@ export const GraphProvider = ({
     }))
   }, [])
 
+  const removeSourceEndpoint = useCallback((id: string) => {
+    setSourceEndpoints((endpoints) => {
+      const next = { ...endpoints }
+      delete next[id]
+      return next
+    })
+  }, [])
+
   const addTargetEndpoint = useCallback((endpoint: Endpoint) => {
     setTargetEndpoints((endpoints) => ({
       ...endpoints,
       [endpoint.id]: endpoint,
     }))
+  }, [])
+
+  const removeTargetEndpoint = useCallback((id: string) => {
+    setTargetEndpoints((endpoints) => {
+      const next = { ...endpoints }
+      delete next[id]
+      return next
+    })
   }, [])
 
   const updateBlockCoordinates = useCallback(
@@ -260,7 +280,9 @@ export const GraphProvider = ({
       sourceEndpoints,
       targetEndpoints,
       addSourceEndpoint,
+      removeSourceEndpoint,
       addTargetEndpoint,
+      removeTargetEndpoint,
       openedStepId,
       setOpenedStepId,
       coordinatesStore,
@@ -282,7 +304,9 @@ export const GraphProvider = ({
       sourceEndpoints,
       targetEndpoints,
       addSourceEndpoint,
+      removeSourceEndpoint,
       addTargetEndpoint,
+      removeTargetEndpoint,
       openedStepId,
       setOpenedStepId,
       coordinatesStore,

--- a/apps/builder/contexts/GraphContext.tsx
+++ b/apps/builder/contexts/GraphContext.tsx
@@ -119,6 +119,13 @@ export class CoordinatesStore {
       })
     }
   }
+
+  dispose = () => {
+    if (this.pendingFrame !== null) {
+      cancelAnimationFrame(this.pendingFrame)
+      this.pendingFrame = null
+    }
+  }
 }
 
 /**
@@ -189,6 +196,7 @@ export const GraphProvider = ({
   if (!coordinatesStoreRef.current)
     coordinatesStoreRef.current = new CoordinatesStore()
   const coordinatesStore = coordinatesStoreRef.current
+  const goToBeginingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [focusedBlockId, setFocusedBlockId] = useState<string>()
   const [draggingBlockId, setDraggingBlockId] = useState<string>()
   const { typebot } = useTypebot()
@@ -201,6 +209,13 @@ export const GraphProvider = ({
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blocks])
+
+  useEffect(() => {
+    return () => {
+      if (goToBeginingTimerRef.current) clearTimeout(goToBeginingTimerRef.current)
+      coordinatesStoreRef.current?.dispose()
+    }
+  }, [])
 
   const addSourceEndpoint = useCallback((endpoint: Endpoint) => {
     setSourceEndpoints((endpoints) => ({
@@ -253,7 +268,9 @@ export const GraphProvider = ({
     const centerY = window.innerHeight / 2
     const averageSizeCard = 315
 
-    const timer = setTimeout(() => {
+    if (goToBeginingTimerRef.current) clearTimeout(goToBeginingTimerRef.current)
+    goToBeginingTimerRef.current = setTimeout(() => {
+      goToBeginingTimerRef.current = null
       setGraphPosition((prev) => {
         let calcX = centerX - averageSizeCard / 2 - graphCoordinates.x
         let calcY = centerY - averageSizeCard / 2 - graphCoordinates.y
@@ -265,7 +282,6 @@ export const GraphProvider = ({
 
         return { x: calcX, y: calcY, scale: 1 }
       })
-      clearTimeout(timer)
     }, 300)
   }, [typebot])
 

--- a/apps/builder/contexts/GraphContext.tsx
+++ b/apps/builder/contexts/GraphContext.tsx
@@ -5,10 +5,13 @@ import {
   MutableRefObject,
   ReactNode,
   SetStateAction,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
+  useSyncExternalStore,
 } from 'react'
 import { useTypebot } from './TypebotContext'
 
@@ -59,12 +62,72 @@ export type Endpoint = {
 
 export type BlocksCoordinates = IdMap<Coordinates>
 
-const graphContext = createContext<{
-  blocksCoordinates: BlocksCoordinates
-  updateBlockCoordinates: (blockId: string, newCoord: Coordinates) => void
+type CoordinatesListener = () => void
+
+/**
+ * Store externo das coordenadas dos blocos.
+ *
+ * Mantém as coordenadas fora do `value` do React context para que arrastar um
+ * bloco não recrie o context e re-renderize TODOS os consumidores. Cada
+ * componente assina via `useSyncExternalStore` e só re-renderiza quando a fatia
+ * que ele lê muda de identidade (a coordenada do seu próprio bloco, ou o objeto
+ * inteiro para quem precisa de todas).
+ */
+export class CoordinatesStore {
+  private coordinates: BlocksCoordinates = {}
+  private listeners = new Set<CoordinatesListener>()
+  private ready = false
+
+  getSnapshot = (): BlocksCoordinates => this.coordinates
+
+  getBlock = (blockId?: string): Coordinates | undefined =>
+    blockId ? this.coordinates[blockId] : undefined
+
+  isReady = (): boolean => this.ready
+
+  subscribe = (listener: CoordinatesListener): (() => void) => {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private emit() {
+    this.listeners.forEach((listener) => listener())
+  }
+
+  setAll = (coordinates: BlocksCoordinates) => {
+    this.coordinates = coordinates
+    this.ready = true
+    this.emit()
+  }
+
+  update = (blockId: string, newCoord: Coordinates) => {
+    const current = this.coordinates[blockId]
+    if (current && current.x === newCoord.x && current.y === newCoord.y) return
+    this.coordinates = { ...this.coordinates, [blockId]: newCoord }
+    this.emit()
+  }
+}
+
+/**
+ * Context isolado para a posição do grafo (pan/zoom). Separado do `graphContext`
+ * para que mudanças de pan/zoom NÃO recriem o value do context principal e
+ * re-renderizem todos os consumidores. Quem só precisa do `scale` em handlers
+ * de drag deve usar `getGraphPosition()` (leitura imperativa, sem assinatura).
+ */
+const graphPositionContext = createContext<{
   graphPosition: Position
-  goToBegining: () => void
   setGraphPosition: Dispatch<SetStateAction<Position>>
+}>({
+  graphPosition: graphPositionDefaultValue,
+  setGraphPosition: () => undefined,
+})
+
+const graphContext = createContext<{
+  updateBlockCoordinates: (blockId: string, newCoord: Coordinates) => void
+  goToBegining: () => void
+  getGraphPosition: () => Position
   connectingIds: ConnectingIds | null
   setConnectingIds: Dispatch<SetStateAction<ConnectingIds | null>>
   previewingEdge?: Edge
@@ -82,8 +145,9 @@ const graphContext = createContext<{
   setDraggingBlockId: Dispatch<SetStateAction<string | undefined>>
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   //@ts-ignore
+  coordinatesStore: CoordinatesStore
+  getBlockCoordinates: (blockId?: string) => Coordinates | undefined
 }>({
-  graphPosition: graphPositionDefaultValue,
   connectingIds: null,
 })
 
@@ -97,53 +161,58 @@ export const GraphProvider = ({
   isReadOnly?: boolean
 }) => {
   const [graphPosition, setGraphPosition] = useState(graphPositionDefaultValue)
+  // Espelho síncrono da posição para leitura imperativa (sem assinatura).
+  const graphPositionRef = useRef(graphPosition)
+  graphPositionRef.current = graphPosition
+  const getGraphPosition = useCallback(() => graphPositionRef.current, [])
   const [connectingIds, setConnectingIds] = useState<ConnectingIds | null>(null)
   const [previewingEdge, setPreviewingEdge] = useState<Edge>()
   const [sourceEndpoints, setSourceEndpoints] = useState<IdMap<Endpoint>>({})
   const [targetEndpoints, setTargetEndpoints] = useState<IdMap<Endpoint>>({})
   const [openedStepId, setOpenedStepId] = useState<string>()
-  const [blocksCoordinates, setBlocksCoordinates] = useState<BlocksCoordinates>(
-    {}
-  )
+  const coordinatesStoreRef = useRef<CoordinatesStore>()
+  if (!coordinatesStoreRef.current)
+    coordinatesStoreRef.current = new CoordinatesStore()
+  const coordinatesStore = coordinatesStoreRef.current
   const [focusedBlockId, setFocusedBlockId] = useState<string>()
   const [draggingBlockId, setDraggingBlockId] = useState<string>()
   const { typebot } = useTypebot()
 
   useEffect(() => {
-    setBlocksCoordinates(
-      blocks.reduce(
-        (coords, block) => ({
-          ...coords,
-          [block.id]: block.graphCoordinates,
-        }),
-        {}
+    coordinatesStore.setAll(
+      Object.fromEntries(
+        blocks.map((block) => [block.id, block.graphCoordinates])
       )
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blocks])
 
-  const addSourceEndpoint = (endpoint: Endpoint) => {
+  const addSourceEndpoint = useCallback((endpoint: Endpoint) => {
     setSourceEndpoints((endpoints) => ({
       ...endpoints,
       [endpoint.id]: endpoint,
     }))
-  }
+  }, [])
 
-  const addTargetEndpoint = (endpoint: Endpoint) => {
+  const addTargetEndpoint = useCallback((endpoint: Endpoint) => {
     setTargetEndpoints((endpoints) => ({
       ...endpoints,
       [endpoint.id]: endpoint,
     }))
-  }
+  }, [])
 
-  const updateBlockCoordinates = (blockId: string, newCoord: Coordinates) =>
-    setBlocksCoordinates((blocksCoordinates) => ({
-      ...blocksCoordinates,
-      [blockId]: newCoord,
-    }))
+  const updateBlockCoordinates = useCallback(
+    (blockId: string, newCoord: Coordinates) =>
+      coordinatesStore.update(blockId, newCoord),
+    [coordinatesStore]
+  )
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const goToBegining = () => {
+  const getBlockCoordinates = useCallback(
+    (blockId?: string) => coordinatesStore.getBlock(blockId),
+    [coordinatesStore]
+  )
+
+  const goToBegining = useCallback(() => {
     const stepStart = typebot?.blocks.find((block) =>
       block.steps.find((step) => step.type === 'start')
     )
@@ -153,25 +222,26 @@ export const GraphProvider = ({
     const centerY = window.innerHeight / 2
     const averageSizeCard = 315
 
-    let calcX = centerX - averageSizeCard / 2 - graphCoordinates.x
-    let calcY = centerY - averageSizeCard / 2 - graphCoordinates.y
-
-    if (graphPosition.x === calcX && graphPosition.y === calcY) {
-      calcX = calcX + 1
-      calcY = calcY + 1
-    }
-
     const timer = setTimeout(() => {
-      setGraphPosition({ x: calcX, y: calcY, scale: 1 })
+      setGraphPosition((prev) => {
+        let calcX = centerX - averageSizeCard / 2 - graphCoordinates.x
+        let calcY = centerY - averageSizeCard / 2 - graphCoordinates.y
+
+        if (prev.x === calcX && prev.y === calcY) {
+          calcX = calcX + 1
+          calcY = calcY + 1
+        }
+
+        return { x: calcX, y: calcY, scale: 1 }
+      })
       clearTimeout(timer)
     }, 300)
-  }
+  }, [typebot])
 
   const contextValue = useMemo(
     () => ({
-      graphPosition,
-      setGraphPosition,
       goToBegining,
+      getGraphPosition,
       connectingIds,
       setConnectingIds,
       previewingEdge,
@@ -182,8 +252,9 @@ export const GraphProvider = ({
       addTargetEndpoint,
       openedStepId,
       setOpenedStepId,
-      blocksCoordinates,
+      coordinatesStore,
       updateBlockCoordinates,
+      getBlockCoordinates,
       isReadOnly,
       focusedBlockId,
       setFocusedBlockId,
@@ -191,9 +262,8 @@ export const GraphProvider = ({
       setDraggingBlockId,
     }),
     [
-      graphPosition,
-      setGraphPosition,
       goToBegining,
+      getGraphPosition,
       connectingIds,
       setConnectingIds,
       previewingEdge,
@@ -204,8 +274,9 @@ export const GraphProvider = ({
       addTargetEndpoint,
       openedStepId,
       setOpenedStepId,
-      blocksCoordinates,
+      coordinatesStore,
       updateBlockCoordinates,
+      getBlockCoordinates,
       isReadOnly,
       focusedBlockId,
       setFocusedBlockId,
@@ -214,11 +285,63 @@ export const GraphProvider = ({
     ]
   )
 
+  const graphPositionValue = useMemo(
+    () => ({ graphPosition, setGraphPosition }),
+    [graphPosition]
+  )
+
   return (
-    <graphContext.Provider value={contextValue}>
-      {children}
-    </graphContext.Provider>
+    <graphPositionContext.Provider value={graphPositionValue}>
+      <graphContext.Provider value={contextValue}>
+        {children}
+      </graphContext.Provider>
+    </graphPositionContext.Provider>
   )
 }
 
 export const useGraph = () => useContext(graphContext)
+
+export const useGraphPosition = () => useContext(graphPositionContext)
+
+/**
+ * Assina a coordenada de UM bloco. O componente só re-renderiza quando a
+ * coordenada desse bloco muda — arrastar outro bloco não o afeta.
+ */
+export const useBlockCoordinates = (blockId?: string) => {
+  const { coordinatesStore } = useContext(graphContext)
+  const getSnapshot = useCallback(
+    () => coordinatesStore.getBlock(blockId),
+    [coordinatesStore, blockId]
+  )
+  return useSyncExternalStore(
+    coordinatesStore.subscribe,
+    getSnapshot,
+    getSnapshot
+  )
+}
+
+/**
+ * Assina o mapa completo de coordenadas. Use apenas onde realmente é preciso
+ * conhecer todas (ex.: cálculo de visibilidade). Re-renderiza a cada mudança.
+ */
+export const useAllBlocksCoordinates = (): BlocksCoordinates => {
+  const { coordinatesStore } = useContext(graphContext)
+  return useSyncExternalStore(
+    coordinatesStore.subscribe,
+    coordinatesStore.getSnapshot,
+    coordinatesStore.getSnapshot
+  )
+}
+
+/**
+ * Booleano que vira `true` quando as coordenadas iniciais foram carregadas.
+ * Estável: só dispara re-render na transição false → true.
+ */
+export const useCoordinatesReady = (): boolean => {
+  const { coordinatesStore } = useContext(graphContext)
+  return useSyncExternalStore(
+    coordinatesStore.subscribe,
+    coordinatesStore.isReady,
+    coordinatesStore.isReady
+  )
+}

--- a/apps/builder/contexts/GraphContext.tsx
+++ b/apps/builder/contexts/GraphContext.tsx
@@ -77,6 +77,7 @@ export class CoordinatesStore {
   private coordinates: BlocksCoordinates = {}
   private listeners = new Set<CoordinatesListener>()
   private ready = false
+  private pendingFrame: number | null = null
 
   getSnapshot = (): BlocksCoordinates => this.coordinates
 
@@ -97,6 +98,10 @@ export class CoordinatesStore {
   }
 
   setAll = (coordinates: BlocksCoordinates) => {
+    if (this.pendingFrame !== null) {
+      cancelAnimationFrame(this.pendingFrame)
+      this.pendingFrame = null
+    }
     this.coordinates = coordinates
     this.ready = true
     this.emit()
@@ -106,7 +111,13 @@ export class CoordinatesStore {
     const current = this.coordinates[blockId]
     if (current && current.x === newCoord.x && current.y === newCoord.y) return
     this.coordinates = { ...this.coordinates, [blockId]: newCoord }
-    this.emit()
+
+    if (this.pendingFrame === null) {
+      this.pendingFrame = requestAnimationFrame(() => {
+        this.pendingFrame = null
+        this.emit()
+      })
+    }
   }
 }
 

--- a/apps/builder/contexts/TypebotContext/TypebotContext.tsx
+++ b/apps/builder/contexts/TypebotContext/TypebotContext.tsx
@@ -76,7 +76,8 @@ type SaveResponse = {
 }
 
 export type SetTypebot = (
-  newPresent: Typebot | ((current: Typebot) => Typebot)
+  newPresent: Typebot | ((current: Typebot) => Typebot),
+  options?: { updateDate?: boolean; skipConnectionsUpdate?: boolean }
 ) => void
 export type SetEmptyFields = (
   values: EmptyFields[] | string[],
@@ -129,6 +130,21 @@ const typebotContext = createContext<
     VariablesActions &
     EdgesActions
 >({} as any)
+
+/**
+ * Context separado só para as ações de mutação (estáveis). Permite que
+ * componentes que só precisam disparar mutações consumam `useTypebotActions()`
+ * sem assinar os dados do typebot — evitando re-render a cada edição.
+ * As mesmas ações continuam disponíveis em `useTypebot()` por compatibilidade.
+ */
+export type TypebotActions = BlocksActions &
+  StepsActions &
+  ItemsActions &
+  VariablesActions &
+  EdgesActions
+const typebotActionsContext = createContext<TypebotActions>(
+  {} as TypebotActions
+)
 
 export const TypebotContext = ({
   children,
@@ -649,6 +665,27 @@ export const TypebotContext = ({
 
   const { wozProfiles } = useWozProfiles()
 
+  // Ações memoizadas UMA vez: dependem só de setters estáveis
+  // (`setLocalTypebot` e `setEmptyFields` são `useCallback([])`). Antes eram
+  // recriadas a cada edição do typebot (estavam dentro do useMemo do value),
+  // o que invalidava deps de effects/memo em todos os ~90 consumidores.
+  const actions = useMemo(
+    () => ({
+      ...blocksActions(
+        setLocalTypebot as SetTypebot,
+        setEmptyFields as SetEmptyFields
+      ),
+      ...stepsAction(
+        setLocalTypebot as SetTypebot,
+        setEmptyFields as SetEmptyFields
+      ),
+      ...variablesAction(setLocalTypebot as SetTypebot),
+      ...edgesAction(setLocalTypebot as SetTypebot),
+      ...itemsAction(setLocalTypebot as SetTypebot),
+    }),
+    [setLocalTypebot, setEmptyFields]
+  )
+
   const contextValue = useMemo(() => {
     return {
       domain,
@@ -675,17 +712,7 @@ export const TypebotContext = ({
       restorePublishedTypebot,
       updateOnBothTypebots,
       updateWebhook,
-      ...blocksActions(
-        setLocalTypebot as SetTypebot,
-        setEmptyFields as SetEmptyFields
-      ),
-      ...stepsAction(
-        setLocalTypebot as SetTypebot,
-        setEmptyFields as SetEmptyFields
-      ),
-      ...variablesAction(setLocalTypebot as SetTypebot),
-      ...edgesAction(setLocalTypebot as SetTypebot),
-      ...itemsAction(setLocalTypebot as SetTypebot),
+      ...actions,
       octaAgents,
       octaGroups,
       botFluxesList,
@@ -716,7 +743,7 @@ export const TypebotContext = ({
     restorePublishedTypebot,
     updateOnBothTypebots,
     updateWebhook,
-    setLocalTypebot,
+    actions,
     octaAgents,
     octaGroups,
     botFluxesList,
@@ -725,12 +752,16 @@ export const TypebotContext = ({
   ])
   return (
     <typebotContext.Provider value={contextValue}>
-      {children}
+      <typebotActionsContext.Provider value={actions}>
+        {children}
+      </typebotActionsContext.Provider>
     </typebotContext.Provider>
   )
 }
 
 export const useTypebot = () => useContext(typebotContext)
+
+export const useTypebotActions = () => useContext(typebotActionsContext)
 
 export const useFetchedTypebot = ({
   typebotId,

--- a/apps/builder/contexts/TypebotContext/TypebotContext.tsx
+++ b/apps/builder/contexts/TypebotContext/TypebotContext.tsx
@@ -13,10 +13,14 @@ import {
   Dispatch,
   ReactNode,
   SetStateAction,
+  useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
+  useSyncExternalStore,
 } from 'react'
 import {
   createPublishedTypebot,
@@ -145,6 +149,60 @@ export type TypebotActions = BlocksActions &
 const typebotActionsContext = createContext<TypebotActions>(
   {} as TypebotActions
 )
+
+/**
+ * Store externo que espelha o `localTypebot` (+ `emptyFields`) para permitir
+ * subscrição POR FATIA via `useSyncExternalStore`. Assim os componentes da
+ * subárvore do nó (BlockNode/StepNode/conteúdos) assinam só o que usam
+ * (ex.: `variables`, `edges`, um bloco) e não re-renderizam a cada edição do
+ * typebot. Sob o immer, fatias não alteradas mantêm a mesma referência, então
+ * o seletor faz bail-out por `Object.is`.
+ */
+class TypebotStore {
+  private typebot?: Typebot
+  private emptyFields: EmptyFields[] = []
+  private listeners = new Set<() => void>()
+
+  setSnapshot = (typebot: Typebot | undefined, emptyFields: EmptyFields[]) => {
+    this.typebot = typebot
+    this.emptyFields = emptyFields
+  }
+
+  getTypebot = (): Typebot | undefined => this.typebot
+  getEmptyFields = (): EmptyFields[] => this.emptyFields
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  emit = () => {
+    this.listeners.forEach((listener) => listener())
+  }
+}
+
+const typebotStoreContext = createContext<TypebotStore>(new TypebotStore())
+
+/**
+ * Dados estáveis / de baixa frequência (listas auxiliares, variáveis custom,
+ * typebots vinculados, setter de hideEdges...). Mudam só quando seus fetches
+ * resolvem — não a cada edição do typebot. Componentes que leem apenas isto
+ * deixam de re-renderizar ao editar steps.
+ */
+type TypebotExtras = {
+  octaAgents: Array<any>
+  octaGroups: Array<any>
+  botFluxesList: Array<any>
+  tagsList: Array<any>
+  wozProfiles?: Array<any>
+  customVariables: ICustomVariable[]
+  linkedTypebots?: Typebot[]
+  setHideEdges: Dispatch<SetStateAction<boolean>>
+  setEmptyFields: SetEmptyFields
+}
+const typebotExtrasContext = createContext<TypebotExtras>({} as TypebotExtras)
 
 export const TypebotContext = ({
   children,
@@ -665,6 +723,42 @@ export const TypebotContext = ({
 
   const { wozProfiles } = useWozProfiles()
 
+  // Store que espelha o typebot para subscrição por fatia. Atualizamos a snapshot
+  // de forma síncrona em todo render (barato) para `getSnapshot` nunca ler stale,
+  // e notificamos os assinantes após o commit (layout effect) quando muda.
+  const typebotStoreRef = useRef<TypebotStore>()
+  if (!typebotStoreRef.current) typebotStoreRef.current = new TypebotStore()
+  const typebotStore = typebotStoreRef.current
+  typebotStore.setSnapshot(localTypebot, emptyFields)
+  useLayoutEffect(() => {
+    typebotStore.emit()
+  }, [localTypebot, typebotStore])
+
+  const extrasValue = useMemo<TypebotExtras>(
+    () => ({
+      octaAgents,
+      octaGroups,
+      botFluxesList,
+      tagsList,
+      wozProfiles,
+      customVariables,
+      linkedTypebots,
+      setHideEdges,
+      setEmptyFields,
+    }),
+    [
+      octaAgents,
+      octaGroups,
+      botFluxesList,
+      tagsList,
+      wozProfiles,
+      customVariables,
+      linkedTypebots,
+      setHideEdges,
+      setEmptyFields,
+    ]
+  )
+
   // Ações memoizadas UMA vez: dependem só de setters estáveis
   // (`setLocalTypebot` e `setEmptyFields` são `useCallback([])`). Antes eram
   // recriadas a cada edição do typebot (estavam dentro do useMemo do value),
@@ -752,9 +846,13 @@ export const TypebotContext = ({
   ])
   return (
     <typebotContext.Provider value={contextValue}>
-      <typebotActionsContext.Provider value={actions}>
-        {children}
-      </typebotActionsContext.Provider>
+      <typebotStoreContext.Provider value={typebotStore}>
+        <typebotExtrasContext.Provider value={extrasValue}>
+          <typebotActionsContext.Provider value={actions}>
+            {children}
+          </typebotActionsContext.Provider>
+        </typebotExtrasContext.Provider>
+      </typebotStoreContext.Provider>
     </typebotContext.Provider>
   )
 }
@@ -762,6 +860,56 @@ export const TypebotContext = ({
 export const useTypebot = () => useContext(typebotContext)
 
 export const useTypebotActions = () => useContext(typebotActionsContext)
+
+export const useTypebotExtras = () => useContext(typebotExtrasContext)
+
+/**
+ * Acessor NÃO-reativo do typebot atual — para uso em handlers/effects sem
+ * assinar (não causa re-render). Para ler dados em render, use
+ * `useTypebotSelector`.
+ */
+export const useGetTypebot = () => {
+  const store = useContext(typebotStoreContext)
+  return store.getTypebot
+}
+
+/** Acessor não-reativo de emptyFields (uso em effects de validação). */
+export const useGetEmptyFields = () => {
+  const store = useContext(typebotStoreContext)
+  return store.getEmptyFields
+}
+
+/**
+ * Subscreve uma FATIA do typebot. O componente só re-renderiza quando o valor
+ * selecionado muda de identidade (`Object.is`). O seletor DEVE retornar uma
+ * referência existente (fatia) ou primitivo — nunca um objeto recém-criado.
+ */
+export function useTypebotSelector<T>(
+  selector: (typebot: Typebot | undefined) => T
+): T {
+  const store = useContext(typebotStoreContext)
+  const lastTypebot = useRef<Typebot | undefined>(undefined)
+  const lastSelected = useRef<T>(undefined as unknown as T)
+  const hasValue = useRef(false)
+  const getSnapshot = () => {
+    const current = store.getTypebot()
+    if (!hasValue.current || lastTypebot.current !== current) {
+      lastTypebot.current = current
+      lastSelected.current = selector(current)
+      hasValue.current = true
+    }
+    return lastSelected.current
+  }
+  return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot)
+}
+
+/** Atalhos comuns construídos sobre `useTypebotSelector`. */
+export const useTypebotVariables = () =>
+  useTypebotSelector((t) => t?.variables)
+export const useTypebotEdges = () => useTypebotSelector((t) => t?.edges)
+export const useTypebotAvailableFor = () =>
+  useTypebotSelector((t) => t?.availableFor)
+export const useHasTypebot = () => useTypebotSelector((t) => !!t)
 
 export const useFetchedTypebot = ({
   typebotId,

--- a/apps/builder/contexts/TypebotContext/TypebotContext.tsx
+++ b/apps/builder/contexts/TypebotContext/TypebotContext.tsx
@@ -135,12 +135,6 @@ const typebotContext = createContext<
     EdgesActions
 >({} as any)
 
-/**
- * Context separado só para as ações de mutação (estáveis). Permite que
- * componentes que só precisam disparar mutações consumam `useTypebotActions()`
- * sem assinar os dados do typebot — evitando re-render a cada edição.
- * As mesmas ações continuam disponíveis em `useTypebot()` por compatibilidade.
- */
 export type TypebotActions = BlocksActions &
   StepsActions &
   ItemsActions &
@@ -150,14 +144,6 @@ const typebotActionsContext = createContext<TypebotActions>(
   {} as TypebotActions
 )
 
-/**
- * Store externo que espelha o `localTypebot` (+ `emptyFields`) para permitir
- * subscrição POR FATIA via `useSyncExternalStore`. Assim os componentes da
- * subárvore do nó (BlockNode/StepNode/conteúdos) assinam só o que usam
- * (ex.: `variables`, `edges`, um bloco) e não re-renderizam a cada edição do
- * typebot. Sob o immer, fatias não alteradas mantêm a mesma referência, então
- * o seletor faz bail-out por `Object.is`.
- */
 class TypebotStore {
   private typebot?: Typebot
   private emptyFields: EmptyFields[] = []
@@ -185,12 +171,6 @@ class TypebotStore {
 
 const typebotStoreContext = createContext<TypebotStore>(new TypebotStore())
 
-/**
- * Dados estáveis / de baixa frequência (listas auxiliares, variáveis custom,
- * typebots vinculados, setter de hideEdges...). Mudam só quando seus fetches
- * resolvem — não a cada edição do typebot. Componentes que leem apenas isto
- * deixam de re-renderizar ao editar steps.
- */
 type TypebotExtras = {
   octaAgents: Array<any>
   octaGroups: Array<any>
@@ -734,9 +714,6 @@ export const TypebotContext = ({
 
   const { wozProfiles } = useWozProfiles()
 
-  // Store que espelha o typebot para subscrição por fatia. Atualizamos a snapshot
-  // de forma síncrona em todo render (barato) para `getSnapshot` nunca ler stale,
-  // e notificamos os assinantes após o commit (layout effect) quando muda.
   const typebotStoreRef = useRef<TypebotStore>()
   if (!typebotStoreRef.current) typebotStoreRef.current = new TypebotStore()
   const typebotStore = typebotStoreRef.current
@@ -770,10 +747,6 @@ export const TypebotContext = ({
     ]
   )
 
-  // Ações memoizadas UMA vez: dependem só de setters estáveis
-  // (`setLocalTypebot` e `setEmptyFields` são `useCallback([])`). Antes eram
-  // recriadas a cada edição do typebot (estavam dentro do useMemo do value),
-  // o que invalidava deps de effects/memo em todos os ~90 consumidores.
   const actions = useMemo(
     () => ({
       ...blocksActions(
@@ -874,27 +847,16 @@ export const useTypebotActions = () => useContext(typebotActionsContext)
 
 export const useTypebotExtras = () => useContext(typebotExtrasContext)
 
-/**
- * Acessor NÃO-reativo do typebot atual — para uso em handlers/effects sem
- * assinar (não causa re-render). Para ler dados em render, use
- * `useTypebotSelector`.
- */
 export const useGetTypebot = () => {
   const store = useContext(typebotStoreContext)
   return store.getTypebot
 }
 
-/** Acessor não-reativo de emptyFields (uso em effects de validação). */
 export const useGetEmptyFields = () => {
   const store = useContext(typebotStoreContext)
   return store.getEmptyFields
 }
 
-/**
- * Subscreve uma FATIA do typebot. O componente só re-renderiza quando o valor
- * selecionado muda de identidade (`Object.is`). O seletor DEVE retornar uma
- * referência existente (fatia) ou primitivo — nunca um objeto recém-criado.
- */
 export function useTypebotSelector<T>(
   selector: (typebot: Typebot | undefined) => T
 ): T {
@@ -914,7 +876,6 @@ export function useTypebotSelector<T>(
   return useSyncExternalStore(store.subscribe, getSnapshot, getSnapshot)
 }
 
-/** Atalhos comuns construídos sobre `useTypebotSelector`. */
 export const useTypebotVariables = () =>
   useTypebotSelector((t) => t?.variables)
 export const useTypebotEdges = () => useTypebotSelector((t) => t?.edges)

--- a/apps/builder/contexts/TypebotContext/actions/blocks.ts
+++ b/apps/builder/contexts/TypebotContext/actions/blocks.ts
@@ -65,11 +65,6 @@ const blocksActions = (
       })
     ),
   updateBlock: (blockIndex: number, updates: Partial<Omit<Block, 'id'>>) => {
-    // `hasConnection` depende apenas de edges + estrutura de steps. Em updates
-    // de coordenada/título (os únicos callers atuais), pulamos o recálculo
-    // O(blocks×steps×edges) que o `set` faz centralmente — caro no caminho
-    // quente do drag (commit de posição via debounce a cada parada). Quando o
-    // update toca `steps`, deixamos o `set` recalcular.
     setTypebot(
       (typebot) =>
         produce(typebot, (typebot) => {

--- a/apps/builder/contexts/TypebotContext/actions/blocks.ts
+++ b/apps/builder/contexts/TypebotContext/actions/blocks.ts
@@ -65,14 +65,18 @@ const blocksActions = (
       })
     ),
   updateBlock: (blockIndex: number, updates: Partial<Omit<Block, 'id'>>) => {
-    setTypebot((typebot) =>
-      produce(typebot, (typebot) => {
-        const block = typebot.blocks[blockIndex]
-
-        typebot.blocks[blockIndex] = { ...block, ...updates }
-
-        typebot.blocks = updateBlocksHasConnections(typebot)
-      })
+    // `hasConnection` depende apenas de edges + estrutura de steps. Em updates
+    // de coordenada/título (os únicos callers atuais), pulamos o recálculo
+    // O(blocks×steps×edges) que o `set` faz centralmente — caro no caminho
+    // quente do drag (commit de posição via debounce a cada parada). Quando o
+    // update toca `steps`, deixamos o `set` recalcular.
+    setTypebot(
+      (typebot) =>
+        produce(typebot, (typebot) => {
+          const block = typebot.blocks[blockIndex]
+          typebot.blocks[blockIndex] = { ...block, ...updates }
+        }),
+      { skipConnectionsUpdate: !updates.steps }
     )
   },
   duplicateBlock: (blockIndex: number) => {

--- a/apps/builder/contexts/TypebotContext/index.ts
+++ b/apps/builder/contexts/TypebotContext/index.ts
@@ -1,1 +1,15 @@
-export { TypebotContext, useTypebot } from './TypebotContext'
+export {
+  TypebotContext,
+  useTypebot,
+  useTypebotActions,
+  useTypebotExtras,
+  useTypebotSelector,
+  useTypebotVariables,
+  useTypebotEdges,
+  useTypebotAvailableFor,
+  useHasTypebot,
+  useGetTypebot,
+  useGetEmptyFields,
+  useFetchedTypebot,
+} from './TypebotContext'
+export type { SetTypebot, SetEmptyFields, TypebotActions } from './TypebotContext'

--- a/apps/builder/hooks/EmptyFields/useEmptyFields.ts
+++ b/apps/builder/hooks/EmptyFields/useEmptyFields.ts
@@ -1,5 +1,5 @@
 import { Step } from 'models'
-import { useReducer } from 'react'
+import { useCallback, useReducer } from 'react'
 
 export type EmptyFields = {
   errorMessage: string[]
@@ -30,9 +30,12 @@ const useEmptyFields = () => {
   const initialState: EmptyFields[] = []
   const [state, dispatch] = useReducer(reducer, initialState)
 
-  const set = (values: EmptyFields[] | string[], type: ActionsType) => {
-    dispatch({ values, type })
-  }
+  const set = useCallback(
+    (values: EmptyFields[] | string[], type: ActionsType) => {
+      dispatch({ values, type })
+    },
+    []
+  )
 
   return { emptyFields: state, setEmptyFields: set }
 }

--- a/apps/builder/hooks/useGraphFocus.ts
+++ b/apps/builder/hooks/useGraphFocus.ts
@@ -1,0 +1,51 @@
+import { useRef } from 'react'
+import { Coordinates, useGraphPosition } from 'contexts/GraphContext'
+import { useTypebotExtras } from 'contexts/TypebotContext'
+
+// Tamanho médio de um card de bloco. Usado para descontar metade do card ao
+// centralizar, de forma que o bloco fique no meio da viewport (não a borda).
+const averageSizeCard = 315
+
+// Tempo até remontar as conexões depois de mover o board. Casa com o
+// `showEdgesTimeOut` do Graph.tsx (o board anima o transform em ~0.1s; 500ms
+// garante que ele já assentou na posição final antes de recalcular as linhas).
+const showEdgesTimeOut = 500
+
+/**
+ * Centraliza o board (pan/zoom) sobre coordenadas de um bloco. Mesma conta
+ * usada em `goToBegining` (GraphContext) e no antigo `focusOnField`
+ * (emptyFieldsItem) — extraída para ser reutilizada.
+ */
+export const useGraphFocus = () => {
+  const { setGraphPosition } = useGraphPosition()
+  const { setHideEdges } = useTypebotExtras()
+
+  const hideEdgesTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+  const focusOnCoordinates = (graphCoordinates?: Coordinates) => {
+    if (!graphCoordinates) return
+
+    // As conexões usam getBoundingClientRect e ficariam tortas se recalculadas
+    // enquanto o board ainda anima. Removemos as linhas antes de mover e as
+    // remontamos depois que o board assenta — recomputando a geometria certa.
+    setHideEdges(true)
+
+    const centerX = window.innerWidth / 2
+    const centerY = window.innerHeight / 2
+
+    const calcX = centerX - averageSizeCard / 2 - graphCoordinates.x
+    const calcY = centerY - averageSizeCard / 2 - graphCoordinates.y
+
+    setGraphPosition({ x: calcX, y: calcY, scale: 1 })
+
+    // Se houver outro focus em sequência, cancela o timer anterior para não
+    // remontar as linhas no meio do próximo movimento.
+    if (hideEdgesTimeoutRef.current) clearTimeout(hideEdgesTimeoutRef.current)
+    hideEdgesTimeoutRef.current = setTimeout(
+      () => setHideEdges(false),
+      showEdgesTimeOut
+    )
+  }
+
+  return { focusOnCoordinates }
+}

--- a/apps/builder/hooks/useGraphFocus.ts
+++ b/apps/builder/hooks/useGraphFocus.ts
@@ -2,20 +2,10 @@ import { useRef } from 'react'
 import { Coordinates, useGraphPosition } from 'contexts/GraphContext'
 import { useTypebotExtras } from 'contexts/TypebotContext'
 
-// Tamanho médio de um card de bloco. Usado para descontar metade do card ao
-// centralizar, de forma que o bloco fique no meio da viewport (não a borda).
 const averageSizeCard = 315
 
-// Tempo até remontar as conexões depois de mover o board. Casa com o
-// `showEdgesTimeOut` do Graph.tsx (o board anima o transform em ~0.1s; 500ms
-// garante que ele já assentou na posição final antes de recalcular as linhas).
 const showEdgesTimeOut = 500
 
-/**
- * Centraliza o board (pan/zoom) sobre coordenadas de um bloco. Mesma conta
- * usada em `goToBegining` (GraphContext) e no antigo `focusOnField`
- * (emptyFieldsItem) — extraída para ser reutilizada.
- */
 export const useGraphFocus = () => {
   const { setGraphPosition } = useGraphPosition()
   const { setHideEdges } = useTypebotExtras()
@@ -25,9 +15,6 @@ export const useGraphFocus = () => {
   const focusOnCoordinates = (graphCoordinates?: Coordinates) => {
     if (!graphCoordinates) return
 
-    // As conexões usam getBoundingClientRect e ficariam tortas se recalculadas
-    // enquanto o board ainda anima. Removemos as linhas antes de mover e as
-    // remontamos depois que o board assenta — recomputando a geometria certa.
     setHideEdges(true)
 
     const centerX = window.innerWidth / 2
@@ -38,8 +25,6 @@ export const useGraphFocus = () => {
 
     setGraphPosition({ x: calcX, y: calcY, scale: 1 })
 
-    // Se houver outro focus em sequência, cancela o timer anterior para não
-    // remontar as linhas no meio do próximo movimento.
     if (hideEdgesTimeoutRef.current) clearTimeout(hideEdgesTimeoutRef.current)
     hideEdgesTimeoutRef.current = setTimeout(
       () => setHideEdges(false),

--- a/apps/builder/hooks/useOuterClick.ts
+++ b/apps/builder/hooks/useOuterClick.ts
@@ -5,26 +5,25 @@ export default function useOuterClick(initialIsVisible: boolean) {
     useState<boolean>(initialIsVisible)
   const ref = useRef<HTMLDivElement>(null)
 
-  const handleHideDropdown = (event: KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      setIsComponentVisible(false)
-    }
-  }
-
-  const handleClickOutside = (event: Event) => {
-    if (ref.current && !ref.current.contains(event.target as Node)) {
-      setIsComponentVisible(false)
-    }
-  }
-
   useEffect(() => {
+    const handleHideDropdown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsComponentVisible(false)
+      }
+    }
+    const handleClickOutside = (event: Event) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setIsComponentVisible(false)
+      }
+    }
     document.addEventListener('keydown', handleHideDropdown, true)
     document.addEventListener('click', handleClickOutside, true)
     return () => {
       document.removeEventListener('keydown', handleHideDropdown, true)
       document.removeEventListener('click', handleClickOutside, true)
     }
-  })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return { ref, isComponentVisible, setIsComponentVisible }
 }

--- a/apps/builder/hooks/useRefreshGraphConnections.ts
+++ b/apps/builder/hooks/useRefreshGraphConnections.ts
@@ -1,10 +1,10 @@
 import { useCallback, useRef } from 'react'
-import { useGraph } from 'contexts/GraphContext'
+import { useGraphPosition } from 'contexts/GraphContext'
 import { Step } from 'models'
 import { stepHasItems } from 'utils'
 
 export const useRefreshGraphConnections = () => {
-  const { setGraphPosition } = useGraph()
+  const { setGraphPosition } = useGraphPosition()
   const timeoutRefs = useRef<Array<ReturnType<typeof setTimeout>>>([])
 
   const refreshConnections = useCallback((step: Step) => {

--- a/apps/builder/pages/typebots/[typebotId]/edit.tsx
+++ b/apps/builder/pages/typebots/[typebotId]/edit.tsx
@@ -7,6 +7,7 @@ import {
 } from 'contexts/EditorContext'
 import { useEffect } from 'react'
 import { BoardMenuButton } from 'components/editor/BoardMenuButton'
+import { BoardMenuButtonSearch } from 'components/editor/BoardMenuButtonSearch'
 import { ToDoList } from 'components/editor/todoList'
 import { StepsSideBar } from 'components/editor/StepsSideBar'
 import { Graph } from 'components/shared/Graph'
@@ -136,7 +137,8 @@ function TypebotEditPage() {
             >
               {typebot && <Graph flex="1" typebot={typebot} />}
 
-              <BoardMenuButton pos="absolute" right="40px" top="20px" />
+              <BoardMenuButton pos="absolute" right="40px" top="20px" aria-label='Lista de pendências' />
+              <BoardMenuButtonSearch pos="absolute" right="40px" top="60px" />
 
               <RightPanel />
             </GraphProvider>

--- a/apps/builder/services/graph.ts
+++ b/apps/builder/services/graph.ts
@@ -306,9 +306,6 @@ export const getEndpointTopOffset = ({
 export const getSourceEndpointId = (edge?: Edge) =>
   edge?.from.itemId ?? edge?.from.stepId
 
-// Cache pela referência do array `steps` (estável sob immer enquanto o bloco não
-// muda). isItemVisible chama isto para TODO bloco a cada re-virtualização; sem
-// cache é O(total blocos × steps) por parada de pan.
 const itemHeightCache = new WeakMap<object, number>()
 
 export const computedItemHeight = (item: any) => {
@@ -343,8 +340,6 @@ export const isItemVisible = (
   const baseBuffer = totalBlocks > MAX_BLOCKS_BUFFER ? 30 : 80
   const scaleBuffer = Math.max(40, baseBuffer / scale)
 
-  // Cap proporcional ao container: evita que em zoom muito baixo o buffer
-  // inclua blocos excessivamente distantes da viewport em coordenadas de mundo.
   const rawBuffer = scaleBuffer + baseBuffer
   const bufferX = Math.min(rawBuffer, containerWidth * 0.10)
   const bufferY = Math.min(rawBuffer, containerHeight * 0.10)

--- a/apps/builder/services/graph.ts
+++ b/apps/builder/services/graph.ts
@@ -340,11 +340,14 @@ export const isItemVisible = (
 ) => {
   const { x, y, scale } = graphPosition
 
-  const baseBuffer = totalBlocks > MAX_BLOCKS_BUFFER ? 50 : 100
-  const scaleBuffer = Math.max(50, baseBuffer / scale)
-  
-  const bufferX = scaleBuffer + baseBuffer
-  const bufferY = scaleBuffer + baseBuffer
+  const baseBuffer = totalBlocks > MAX_BLOCKS_BUFFER ? 30 : 80
+  const scaleBuffer = Math.max(40, baseBuffer / scale)
+
+  // Cap proporcional ao container: evita que em zoom muito baixo o buffer
+  // inclua blocos excessivamente distantes da viewport em coordenadas de mundo.
+  const rawBuffer = scaleBuffer + baseBuffer
+  const bufferX = Math.min(rawBuffer, containerWidth * 0.10)
+  const bufferY = Math.min(rawBuffer, containerHeight * 0.10)
 
   const scaledItemX = Math.abs(
     item.graphCoordinates.x * scale + x - containerWidth / 2
@@ -353,8 +356,8 @@ export const isItemVisible = (
     item.graphCoordinates.y * scale + y - containerHeight / 2
   )
 
-  const itemWidth = (313 + bufferX) * scale // Considerando a largura do item
-  const itemHeight = (computedItemHeight(item) + bufferY) * scale // Considerando a altura do item
+  const itemWidth = (313 + bufferX) * scale
+  const itemHeight = (computedItemHeight(item) + bufferY) * scale
 
   const isHorizontallyVisible = scaledItemX - itemWidth < containerWidth / 2
 

--- a/apps/builder/services/graph.ts
+++ b/apps/builder/services/graph.ts
@@ -306,17 +306,27 @@ export const getEndpointTopOffset = ({
 export const getSourceEndpointId = (edge?: Edge) =>
   edge?.from.itemId ?? edge?.from.stepId
 
-export const computedItemHeight = (item) => {
-  const base = (item.steps.length - 1) * 269 + 500
-  const items = item.steps.filter((item) => item.hasOwnProperty('items'))
-  const itemsLenght = items.reduce((a, c) => {
+// Cache pela referência do array `steps` (estável sob immer enquanto o bloco não
+// muda). isItemVisible chama isto para TODO bloco a cada re-virtualização; sem
+// cache é O(total blocos × steps) por parada de pan.
+const itemHeightCache = new WeakMap<object, number>()
+
+export const computedItemHeight = (item: any) => {
+  const steps = item?.steps
+  if (steps && itemHeightCache.has(steps)) {
+    return itemHeightCache.get(steps) as number
+  }
+
+  const base = (steps.length - 1) * 269 + 500
+  const items = steps.filter((item: any) => item.hasOwnProperty('items'))
+  const itemsLenght = items.reduce((a: number, c: any) => {
     return a + c.items?.length
   }, 0)
 
-  if (itemsLenght > 4) {
-    return (itemsLenght - 4) * 52 + base
-  }
-  return base
+  const result = itemsLenght > 4 ? (itemsLenght - 4) * 52 + base : base
+
+  if (steps) itemHeightCache.set(steps, result)
+  return result
 }
 
 const MAX_BLOCKS_BUFFER = 50

--- a/apps/builder/services/sanitizeHtml.ts
+++ b/apps/builder/services/sanitizeHtml.ts
@@ -1,17 +1,6 @@
 import DOMPurify from 'dompurify'
 import { textBubbleEditorContentConfig } from 'config/dompurify'
 
-/**
- * Cache global de `DOMPurify.sanitize` para o conteúdo das bubbles.
- *
- * Os previews de texto (TextBubbleContent/TextHtmlContent) sanitizam HTML a cada
- * render/mount. Durante a navegação, blocos montam/desmontam o tempo todo
- * (virtualização) → o mesmo HTML é re-sanitizado repetidamente. O profile
- * mostrou isto como ~10-13% do tempo (parseFromString / purify / Parse HTML).
- *
- * A config é constante, então a chave é só a string de HTML. O cache sobrevive a
- * re-mounts, eliminando o custo ao panar de volta por blocos já vistos.
- */
 const cache = new Map<string, string>()
 const MAX_ENTRIES = 2000
 
@@ -21,7 +10,6 @@ export const sanitizeBubbleHtml = (html?: string): string => {
   if (cached !== undefined) return cached
 
   const sanitized = DOMPurify.sanitize(key, textBubbleEditorContentConfig)
-  // Evita crescimento ilimitado (ex.: digitação gera muitas strings distintas).
   if (cache.size >= MAX_ENTRIES) cache.clear()
   cache.set(key, sanitized)
   return sanitized

--- a/apps/builder/services/sanitizeHtml.ts
+++ b/apps/builder/services/sanitizeHtml.ts
@@ -1,0 +1,28 @@
+import DOMPurify from 'dompurify'
+import { textBubbleEditorContentConfig } from 'config/dompurify'
+
+/**
+ * Cache global de `DOMPurify.sanitize` para o conteúdo das bubbles.
+ *
+ * Os previews de texto (TextBubbleContent/TextHtmlContent) sanitizam HTML a cada
+ * render/mount. Durante a navegação, blocos montam/desmontam o tempo todo
+ * (virtualização) → o mesmo HTML é re-sanitizado repetidamente. O profile
+ * mostrou isto como ~10-13% do tempo (parseFromString / purify / Parse HTML).
+ *
+ * A config é constante, então a chave é só a string de HTML. O cache sobrevive a
+ * re-mounts, eliminando o custo ao panar de volta por blocos já vistos.
+ */
+const cache = new Map<string, string>()
+const MAX_ENTRIES = 2000
+
+export const sanitizeBubbleHtml = (html?: string): string => {
+  const key = html ?? ''
+  const cached = cache.get(key)
+  if (cached !== undefined) return cached
+
+  const sanitized = DOMPurify.sanitize(key, textBubbleEditorContentConfig)
+  // Evita crescimento ilimitado (ex.: digitação gera muitas strings distintas).
+  if (cache.size >= MAX_ENTRIES) cache.clear()
+  cache.set(key, sanitized)
+  return sanitized
+}

--- a/apps/builder/services/utils/useUndo.ts
+++ b/apps/builder/services/utils/useUndo.ts
@@ -15,7 +15,7 @@ enum ActionType {
 export interface Actions<T> {
   set: (
     newPresent: T | ((current: T) => T),
-    options?: { updateDate: boolean }
+    options?: { updateDate?: boolean; skipConnectionsUpdate?: boolean }
   ) => void
   undo: () => void
   redo: () => void
@@ -129,21 +129,29 @@ const useUndo = <T>(initialPresent: T): [State<T>, Actions<T>] => {
   }, [canRedo])
 
   const set = useCallback(
-    (newPresent: T | ((current: T) => T), options = { updateDate: true }) => {
+    (
+      newPresent: T | ((current: T) => T),
+      options: { updateDate?: boolean; skipConnectionsUpdate?: boolean } = {}
+    ) => {
+      const { updateDate = true, skipConnectionsUpdate = false } = options
       const updatedTypebot =
         'id' in newPresent
           ? newPresent
           : (newPresent as (current: T) => T)(presentRef.current)
       presentRef.current = updatedTypebot
 
-      if (updatedTypebot?.blocks) {
+      // `hasConnection` só depende de edges + estrutura de steps. Em updates que
+      // não alteram conexões (ex.: coordenadas de bloco no commit do drag), o
+      // caller passa `skipConnectionsUpdate` para evitar este recálculo
+      // O(blocks×steps×edges) no caminho quente.
+      if (updatedTypebot?.blocks && !skipConnectionsUpdate) {
         updatedTypebot.blocks = updateBlocksHasConnections(updatedTypebot)
       }
 
       dispatch({
         type: ActionType.Set,
         newPresent: updatedTypebot,
-        updateDate: options.updateDate,
+        updateDate,
       })
     },
     []

--- a/apps/builder/services/utils/useUndo.ts
+++ b/apps/builder/services/utils/useUndo.ts
@@ -79,10 +79,6 @@ const reducer = <T>(state: State<T>, action: Action<T>) => {
 
     case ActionType.Set: {
       const { newPresent, updateDate, skipHistory } = action
-      // dequal direto faz comparação estrutural profunda com early-exit (para no
-      // 1º campo diferente — o caso comum de uma edição real). Antes serializava
-      // o fluxo INTEIRO 2× com JSON.stringify + parseava 2× a cada mutação.
-
       if (
         isNotDefined(newPresent) ||
         (present && dequal(newPresent, present))
@@ -150,10 +146,6 @@ const useUndo = <T>(initialPresent: T): [State<T>, Actions<T>] => {
           ? newPresent
           : (newPresent as (current: T) => T)(presentRef.current)
 
-      // `hasConnection` só depende de edges + estrutura de steps. Em updates que
-      // não alteram conexões (ex.: coordenadas de bloco no commit do drag), o
-      // caller passa `skipConnectionsUpdate` para evitar este recálculo
-      // O(blocks×steps×edges) no caminho quente.
       if (updatedTypebot?.blocks && !skipConnectionsUpdate) {
         updatedTypebot.blocks = updateBlocksHasConnections(updatedTypebot)
       }

--- a/apps/builder/services/utils/useUndo.ts
+++ b/apps/builder/services/utils/useUndo.ts
@@ -78,13 +78,12 @@ const reducer = <T>(state: State<T>, action: Action<T>) => {
 
     case ActionType.Set: {
       const { newPresent, updateDate } = action
+      // dequal direto faz comparação estrutural profunda com early-exit (para no
+      // 1º campo diferente — o caso comum de uma edição real). Antes serializava
+      // o fluxo INTEIRO 2× com JSON.stringify + parseava 2× a cada mutação.
       if (
         isNotDefined(newPresent) ||
-        (present &&
-          dequal(
-            JSON.parse(JSON.stringify(newPresent)),
-            JSON.parse(JSON.stringify(present))
-          ))
+        (present && dequal(newPresent, present))
       ) {
         return state
       }


### PR DESCRIPTION
# Relatório de Melhorias

## Grupo 1 — Otimizações de Performance

### 1.1 Refactor da arquitetura do contexto do grafo

**Commits:** `feat: refactor in board and bloocks`, `feat: implements tier 2`  
**Arquivos:** `GraphContext.tsx`, `TypebotContext.tsx`, `Graph.tsx`, `GraphContent.tsx`, `BlockNode.tsx`, `StepNodesList.tsx`, `ItemNodesList.tsx`

O `GraphContext` foi reescrito com uma separação clara de responsabilidades:

- **`CoordinatesStore`** — classe que armazena as coordenadas de blocos (posição no canvas) de forma imperativa, com um sistema próprio de `subscribe/unsubscribe`. Componentes que só precisam ler coordenadas para calcular posição CSS o fazem de forma imperativa (sem re-render).
- **Contexto de posição do grafo separado** — pan/zoom ficou em um contexto isolado para que mudanças de navegação não recriem o value do contexto principal e não re-renderizem todos os consumidores.

O `TypebotContext` foi otimizado para granularizar as assinaturas: seletores seletivos por `blockIndex`/`stepIndex` evitam que a árvore inteira re-renderize quando um único bloco muda.

### 1.2 Throttle de emissões do `CoordinatesStore` via `requestAnimationFrame`

**Commit:** `refactor: graph editor performance optimizations`  
**Arquivo:** `GraphContext.tsx` — classe `CoordinatesStore`, método `update`

**Antes:** `update()` chamava `emit()` de forma síncrona a cada `mousemove`. Com 10+ edges por bloco, isso disparava 10+ re-renders por evento — ~600 re-renders por segundo durante drag.

**Depois:** Emissões são agrupadas em um `requestAnimationFrame`. Múltiplas chamadas a `update()` entre dois frames são consolidadas em uma única emissão (~60fps). O método `setAll` cancela o frame pendente antes de emitir, evitando emissão com snapshot stale.

### 1.3 Desacoplamento de `GraphContent` da `CoordinatesStore`

**Commit:** `refactor: graph editor performance optimizations`  
**Arquivo:** `GraphContent.tsx`

**Antes:** `GraphContent` assinava `useAllBlocksCoordinates()`, que emitia a cada pixel de drag. O `useMemo` de `visibleItems` (filtro de virtualização — O(N blocos)) era invalidado a cada pixel.

**Depois:** `GraphContent` não assina mais a `CoordinatesStore`. O filtro usa `block.graphCoordinates` (dado estável do typebot via immer), recalculando apenas quando typebot, posição do grafo ou tamanho do container mudam. Durante drag, `draggingBlockId` garante que o bloco arrastado permaneça visível.

### 1.4 `useDeferredValue` no cálculo de blocos visíveis

**Commit:** `feat: adds useDeferredValue and isSimplified flag`  
**Arquivo:** `GraphContent.tsx`

O cálculo de `visibleItems` foi envolvido em `useDeferredValue`. Interações de alta prioridade (pan, zoom, cliques) não são mais bloqueadas pelo recálculo do filtro de visibilidade.

### 1.5 Modo simplificado para grafos grandes (`isSimplified`)

**Commits:** `feat: adds useDeferredValue and isSimplified flag`, `feat: only applies simplified blocks when more blocks than 50`  
**Arquivos:** `GraphContent.tsx`, `BlockNode.tsx`, `Edge.tsx`, `Edges.tsx`

Quando o grafo tem mais de 50 blocos, `BlockNode` entra em modo `simplified`:
- Renderiza somente o título do bloco em um card reduzido (sem steps, sem endpoints, sem drag)
- Edges são ocultadas no modo simplificado para reduzir nós DOM adicionais

Isso reduz drasticamente o total de nós DOM em grafos grandes.

### 1.6 Memoização de `StepNode` e estabilização de props

**Commit:** `refactor: graph editor performance optimizations`  
**Arquivos:** `StepNode.tsx`, `StepNodesList.tsx`

**Antes:** `StepNode` não era memoizado. O array de `indices` (`{ blockIndex, stepIndex }`) era criado como novo objeto literal a cada render de `StepNodesList`, invalidando qualquer memoização.

**Depois:**
- `StepNode` envolvido em `React.memo` com comparador customizado por referência
- `StepNodesList` usa `useMemo` para estabilizar o array de `indices` (novo objeto só quando o número de steps muda) e `useCallback` para estabilizar `onMouseDown`

Steps só re-renderizam quando suas próprias props mudam.

### 1.7 Ajuste do buffer de virtualização

**Commits:** `feat: tier 3.1`, `refactor: graph editor performance optimizations`  
**Arquivo:** `services/graph.ts`

O buffer além da viewport foi ajustado com um cap proporcional ao container (10%). Em zoom baixo, o buffer não escala mais indefinidamente, reduzindo blocos desnecessários no DOM, sem comprometer o anti-popping durante pan rápido.

### 1.8 Otimização do conteúdo de steps (`StepNodeContent`)

**Commit:** `feat: tier 3`  
**Arquivos:** `StepNodeContent.tsx` e todos os `*Content.tsx` de steps

Os componentes de preview de steps (ex.: `TextBubbleContent`, `AssignToTeamContent`, `InputContent`) foram otimizados para usar seletores mais granulares do `TypebotContext`, evitando re-renders quando dados não relacionados ao step específico mudam.

### 1.9 Busca de blocos

**Commit:** `feat: adds search blocks`  
**Arquivos:** `BoardMenuButtonSearch.tsx`, `useGraphFocus.ts`, `GraphContent.tsx`

Adicionada funcionalidade de busca no painel de edição: o usuário pode buscar blocos por nome e o grafo navega automaticamente até o bloco encontrado (`useGraphFocus`).

---

## Grupo 2 — Correções de Memory Leak (Detached DOM Nodes)

> **O que são "detached nodes"?** São elementos DOM removidos do documento mas ainda referenciados por JavaScript — o garbage collector não pode coletá-los. Acumulam a cada abertura/fechamento de modal.

### 2.1 Lazy-mount do `SettingsModal`

**Commit:** `fix: prevent detached DOM node leaks in the graph editor`  
**Arquivos:** `StepNode.tsx`, `SettingsModal.tsx`

**Antes:** O `SettingsModal` ficava montado permanentemente no DOM junto de cada `StepNode`, mesmo quando fechado. O DOM do modal (~400 nós) existia para cada step visível no grafo.

**Depois:**
- Adicionado estado `modalMounted` (inicia `false`) em `StepNode`
- O modal só monta na primeira abertura (`setModalMounted(true)`)
- `SettingsModal` recebe a prop `onCloseComplete`, encaminhada ao `<Modal>` do Chakra
- Ao fechar, `isOpen` vai para `false` (dispara animação de saída); só após a animação completar é que `onCloseComplete` dispara `setModalMounted(false)`, desmontando o modal sem cortar a animação

### 2.2 Cleanup de endpoints ao desmontar steps

**Commit:** `fix: prevent detached DOM node leaks in the graph editor`  
**Arquivos:** `SourceEndpoint.tsx`, `TargetEndpoint.tsx`, `GraphContext.tsx`

Os endpoints de conexão (pontos de entrada/saída nos blocos) registram seus refs DOM no `GraphContext` via `addSourceEndpoint`/`addTargetEndpoint`. Adicionadas funções `removeSourceEndpoint`/`removeTargetEndpoint` e retornos de cleanup nos `useEffect` dos endpoints, garantindo que refs de steps virtualizados (fora de tela) sejam removidos do contexto ao desmontar.

### 2.3 Limpeza de `mouseOverBlock` ao desmontar `BlockNode`

**Commit:** `fix: prevent detached DOM node leaks in the graph editor`  
**Arquivo:** `BlockNode.tsx`

`StepNodesList` usava `useEventListener(() => mouseOverBlock?.ref.current, ...)` para anexar listeners ao bloco que o cursor estava sobre. O `mouseOverBlock` era capturado no momento em que o efeito rodava (closure). Quando o bloco saía da tela (virtualização), o DOM era removido mas a closure ainda apontava para o div detached.

`BlockNode` agora limpa `mouseOverBlock` no unmount (via cleanup de `useEffect`) se o bloco desmontando for o atual `mouseOverBlock`. Isso garante que o `useEventListener` dos outros componentes libere a closure com a referência stale.

### 2.4 `unmountOnExit` no `Collapse` de `ChoiceInputSettingsBody`

**Commit:** `fix: reduce detached DOM nodes in step settings modal`  
**Arquivo:** `ChoiceInputSettingsBody.tsx`

O `Collapse` da seção de mensagens de fallback (`isCollapsed = false` por padrão = fechado) não tinha `unmountOnExit`. Mesmo com a seção visualmente fechada, 3 instâncias de `TextBubbleEditor` + o `OctaSelect` com 70+ itens de opções ficavam montados no DOM durante toda a vida do modal.

Adicionado `unmountOnExit`: o conteúdo só monta quando o usuário expande a seção.

### 2.5 `useOuterClick` — listeners registrados a cada render

**Commit:** `fix: reduce detached DOM nodes in step settings modal`  
**Arquivo:** `useOuterClick.ts`

O `useEffect` não tinha array de dependências (`[]`), fazendo com que dois event listeners em `document` (`keydown`, `click`) fossem removidos e re-adicionados a cada render do `OctaSelect`.

Handlers foram movidos para dentro do `useEffect` com `deps: []`. Os handlers fecham somente sobre `ref` (`useRef`, estável) e `setIsComponentVisible` (setter do `useState`, estável), então a closure nunca fica stale.

### 2.6 Cleanup do effect de overflow no `OctaSelect`

**Commit:** `fix: reduce detached DOM nodes in step settings modal`  
**Arquivo:** `OctaSelect.tsx`

O `useEffect` que alterava `ModalBody.style.overflow` não tinha função de cleanup. Adicionada função de cleanup que restaura `overflow: auto` quando o componente desmonta ou os deps mudam.

---

## Grupo 3 — Limpeza de Schedulers sem Cleanup

Schedulers não cancelados causam dois problemas: chamadas de `setState` em componentes já desmontados (aviso do React em dev mode, comportamento imprevisível em produção) e referências à memória que impedem o GC.

### 3.1 `IntersectionObserver` sem `disconnect()` — `SubmissionsTable.tsx`

**Commit:** `fix: cancel dangling timers and observers on component unmount`

O `IntersectionObserver` usado para detectar quando o usuário chegava ao fim da tabela de resultados nunca chamava `disconnect()` no unmount. Observer continuava observando um elemento que não existia mais. **Correção:** `return () => observer.disconnect()` adicionado ao `useEffect`.

### 3.2 `setTimeout` aninhados sem IDs — `ContextMenu.tsx`

**Commit:** `fix: cancel dangling timers and observers on component unmount`

Dois `setTimeout` aninhados (para animar a abertura do context menu) não tinham seus IDs armazenados. Se o componente desmontasse antes de dispararem, `setIsRendered` e `setIsDeferredOpen` seriam chamados no estado desmontado. **Correção:** IDs em `outerTimer`/`innerTimer`, ambos cancelados no cleanup junto com o `removeEventListener`.

### 3.3 `setTimeout` de `setIsMovingBoard` — `Graph.tsx`

**Commit:** `fix: cancel dangling timers and observers on component unmount`

O timeout de 500ms que desativa o estado de animação do grafo não tinha cleanup. **Correção:** ID armazenado, `return () => clearTimeout(timer)` adicionado.

### 3.4 Truncation timer e rAF no `TextBubbleEditor` — `TextBubbleEditor.tsx`

**Commit:** `fix: cancel dangling timers and observers on component unmount`

O `setTimeout(0)` que trunca o texto ao atingir `maxLength` — e o `requestAnimationFrame` interno que reposiciona o cursor — não eram rastreados. Se o componente desmontasse com uma operação de truncamento em voo, o Slate editor receberia transforms após o cleanup do Plate.

Adicionados `truncationTimerRef` e `truncationRafRef`. Cada nova invocação cancela a anterior. Ambos são cancelados no `useEffect` de cleanup existente (`deps: []`).

### 3.5 `goToBegining` timer e `CoordinatesStore` pendingFrame — `GraphContext.tsx`

**Commit:** `fix: cancel dangling timers and observers on component unmount`

Dois problemas em `GraphProvider`:
1. `goToBegining` criava um `setTimeout` de 300ms sem armazená-lo. Se chamado múltiplas vezes (possível durante reloads) ou se o provider desmontasse, `setGraphPosition` seria chamado após unmount. O `clearTimeout(timer)` que existia **dentro** do próprio callback era inútil (timer já disparou quando o callback executa).
2. `CoordinatesStore.update` podia ter um `requestAnimationFrame` pendente ao desmontar o provider.

**Correções:**
- `goToBeginingTimerRef` armazena o timer; chamadas repetidas cancelam o anterior
- Adicionado método `dispose()` à `CoordinatesStore` que cancela o frame pendente
- `useEffect` com `[]` no `GraphProvider` chama ambos no unmount

---

## Resumo Geral

| Arquivo | Grupo | O que mudou |
|---|---|---|
| `GraphContext.tsx` | Performance + Cleanup | `CoordinatesStore` com rAF batching e `dispose()`; timer de `goToBegining` com ref; cleanup no unmount |
| `GraphContent.tsx` | Performance | Desacoplamento da `CoordinatesStore`; `useDeferredValue`; modo simplified; busca |
| `services/graph.ts` | Performance | Buffer de virtualização com cap proporcional |
| `BlockNode.tsx` | Performance + Memory | Modo simplified; cleanup de `mouseOverBlock` no unmount |
| `StepNodesList.tsx` | Performance | `useMemo` em `indices`; `useCallback` em `onMouseDown` |
| `StepNode/StepNode.tsx` | Performance + Memory | `React.memo`; lazy-mount do `SettingsModal` via `modalMounted` |
| `SettingsModal.tsx` | Memory | Prop `onCloseComplete` encaminhada ao `<Modal>` |
| `SourceEndpoint.tsx` / `TargetEndpoint.tsx` | Memory | Cleanup remove endpoint do `GraphContext` ao desmontar |
| `ChoiceInputSettingsBody.tsx` | Memory | `unmountOnExit` no `Collapse` |
| `useOuterClick.ts` | Memory | Handlers dentro do `useEffect`; `deps: []` |
| `OctaSelect.tsx` | Memory | Cleanup restaura `overflow` ao desmontar |
| `TextBubbleEditor.tsx` | Cleanup | Refs e cancel para truncation `setTimeout` + `requestAnimationFrame` |
| `SubmissionsTable.tsx` | Cleanup | `observer.disconnect()` no unmount |
| `ContextMenu.tsx` | Cleanup | `clearTimeout` nos timers aninhados |
| `Graph.tsx` | Cleanup | `clearTimeout` no timer de `setIsMovingBoard` |
| `TypebotContext.tsx` + actions | Performance | Seletores granulares; undo otimizado |
| `StepNodeContent/*Content.tsx` | Performance | Seletores mais específicos evitam re-renders |
| `BoardMenuButtonSearch.tsx` / `useGraphFocus.ts` | Feature | Busca de blocos por nome |

