### PR TITLE
fix: impedir que bloco deletado seja renderizado sobre o bloco Início

### DIFF
--- a/apps/builder/components/shared/Graph/GraphContent.tsx
+++ b/apps/builder/components/shared/Graph/GraphContent.tsx
@@ -111,10 +111,11 @@ const MyComponent = memo(
 
         {renderedItems.map((block) => {
           const blockIndex = blockIndexById.get(block.id)
+          if (blockIndex === undefined) return null
           return (
             <BlockNode
               block={block}
-              blockIndex={blockIndex ?? 0}
+              blockIndex={blockIndex}
               simplified={renderedSimplified}
               key={block.id}
             />

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -123,6 +123,8 @@ const StepNodeBase = ({
 
   const isPreviewing = isConnecting || previewingEdge?.to.stepId === step.id
 
+  const isStartStep = step.type === 'start'
+
   const onDrag = (position: NodePosition) => {
     if (step.type === 'start' || !onMouseDown) return
     onMouseDown(position, step)
@@ -130,7 +132,7 @@ const StepNodeBase = ({
   useDragDistance({
     ref: stepRef,
     onDrag,
-    isDisabled: !onMouseDown || step.type === 'start',
+    isDisabled: !onMouseDown || isStartStep,
   })
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
@@ -294,6 +296,7 @@ const StepNodeBase = ({
                 data-testid={`step`}
                 w="full"
                 direction="column"
+                pointerEvents={isStartStep ? 'none' : 'auto'}
               >
                 <Stack spacing={2}>
                   <BlockStack

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodesList.tsx
@@ -186,7 +186,7 @@ export const StepNodesList = ({
     <Stack
       spacing={1}
       transition="none"
-      pointerEvents={isReadOnly || isStartBlock ? 'none' : 'auto'}
+      pointerEvents={isReadOnly ? 'none' : 'auto'}
     >
       <Flex
         ref={handlePushElementRef(0)}

--- a/apps/builder/contexts/TypebotContext/actions/steps.ts
+++ b/apps/builder/contexts/TypebotContext/actions/steps.ts
@@ -51,7 +51,9 @@ const stepsAction = (
   ) =>
     setTypebot((typebot) =>
       produce(typebot, (typebot) => {
-        const step = typebot.blocks[blockIndex].steps[stepIndex]
+        const step = typebot.blocks[blockIndex]?.steps[stepIndex]
+        if (!step) return
+
         const removedReferenceUpdates = JSON.parse(
           JSON.stringify({ ...step, ...updates })
         )


### PR DESCRIPTION
# Descrição

`GraphContent` renderiza os blocos a partir de uma lista atrasada por `useDeferredValue`, mas monta o `blockIndexById` sobre o `typebot.blocks` atual. Um bloco recém-deletado continua na lista atrasada e já não tem entrada no mapa, então caía no fallback `blockIndex ?? 0` — o índice do bloco Início. Sem coordenadas no `CoordinatesStore`, esse bloco fantasma ainda desenhava em `translate(0,0)`, exatamente por cima do Início.

A partir daí, abrir e fechar o modal de configuração de um step do fantasma bastava para corromper o bot: `handleModalClose` sempre chama `updateStep(indices, { ...step })`, e com `blockIndex` 0 e `stepIndex` 1 a atribuição `blocks[0].steps[1] = step` anexava o step configurado dentro do Início. Como a lista de steps do Início tinha `pointerEvents: none`, o step ficava preso sem como remover.

Não afeta a execução do bot: o motor encerra o bloco no step `start`, então o step órfão nunca roda. Bots já salvos seguem com o step até que alguém o remova pela interface.

- `GraphContent.tsx`: bloco sem entrada no mapa de índices não é renderizado, em vez de cair em `blockIndex ?? 0`
- `actions/steps.ts`: `updateStep` não grava quando não existe step no índice alvo
- `StepNodesList.tsx` e `StepNode/StepNode.tsx`: `pointerEvents` deixa de bloquear a lista inteira do bloco Início e passa a travar apenas o step `start`, permitindo remover o que já ficou preso

Incidente: CHAT-2807
