### PR TITLE
fix: trocar imagem base do Dockerfile para bookworm

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # https://github.com/vercel/turborepo/issues/215#issuecomment-1027058056
 #FROM node:18-slim AS base
-FROM node:18-bullseye-slim AS base
+FROM node:18-bookworm-slim AS base
 WORKDIR /app
 ARG SCOPE
 ENV SCOPE=${SCOPE}


### PR DESCRIPTION
# Descrição

O build quebra em `apt-get -qy update`, que roda duas vezes no Dockerfile, nos estágios `builder` e `runner`:

```
E: Release file for .../bullseye-security/InRelease is expired (invalid since 1d 19h 43min 1s)
```

O Debian 11 (bullseye) saiu de suporte e o `Release` do repositório de segurança não será republicado. O `apt` trata `Release` vencido como erro fatal e sai com código 100; como o comando usa `&&`, o `install` nem chega a rodar. O prazo só cresce a cada tentativa, então é determinístico, não instabilidade — qualquer build do repositório falha hoje.

A correção é trocar a imagem base para Debian 12 (bookworm), com suporte até 2028. As duas chamadas de `apt-get` continuam como estão e voltam a funcionar, porque o `Release` do bookworm é válido. Node segue no 18.

Bookworm traz OpenSSL 3 no lugar do 1.1. Esse `apt-get install openssl` é herança do Typebot original, que usava Prisma e precisava da libssl para os binários do engine; não há Prisma neste repositório (`packages/db` tem `dependencies` vazio), então a troca não deve ter efeito prático. Remover as duas chamadas fica para um PR separado.

- `build/Dockerfile`: base passa de `node:18-bullseye-slim` para `node:18-bookworm-slim`
