### PR TITLE
fix: manter texto digitado nas opções de múltipla escolha

### DIFF
--- a/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ButtonNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/ItemNode/ItemNodeContent/contents/ButtonNodeContent.tsx
@@ -23,14 +23,22 @@ export const ButtonNodeContent = ({ item, indices, onUpdateItem }: Props) => {
     item.content ?? defaultPlaceholder
   )
   const editableRef = useRef<HTMLDivElement | null>(null)
+  const isEditingRef = useRef(false)
+  const itemValueRef = useRef(itemValue)
+  const itemContentRef = useRef(item.content)
+  const commitPendingEditRef = useRef<(() => void) | null>(null)
+
+  itemValueRef.current = itemValue
+  itemContentRef.current = item.content
 
   useEffect(() => {
-    if (itemValue !== item.content)
-      setItemValue(item.content ?? defaultPlaceholder)
+    if (isEditingRef.current) return
+    setItemValue(item.content ?? defaultPlaceholder)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [item])
+  }, [item.content])
 
   const handleInputSubmit = () => {
+    isEditingRef.current = false
     if (itemValue === '') deleteItem(indices)
     else {
       const newValue = itemValue === '' ? undefined : itemValue
@@ -39,6 +47,31 @@ export const ButtonNodeContent = ({ item, indices, onUpdateItem }: Props) => {
         onUpdateItem(newValue || '')
       }
     }
+  }
+
+  const commitPendingEdit = () => {
+    const pendingValue = itemValueRef.current
+    if (!isEditingRef.current) return
+    if (pendingValue === '' || pendingValue === defaultPlaceholder) return
+    if (pendingValue === itemContentRef.current) return
+    updateItem(indices, { content: pendingValue })
+    if (onUpdateItem) onUpdateItem(pendingValue)
+  }
+
+  commitPendingEditRef.current = commitPendingEdit
+
+  useEffect(
+    () => () => commitPendingEditRef.current?.(),
+    []
+  )
+
+  const handleEditStart = () => {
+    isEditingRef.current = true
+  }
+
+  const handleEditCancel = () => {
+    isEditingRef.current = false
+    setItemValue(item.content ?? defaultPlaceholder)
   }
 
   const hasMoreThanOneItem = () => indices.itemsCount && indices.itemsCount > 1
@@ -73,6 +106,8 @@ export const ButtonNodeContent = ({ item, indices, onUpdateItem }: Props) => {
         startWithEditView={false}
         value={itemValue}
         onChange={setItemValue}
+        onEdit={handleEditStart}
+        onCancel={handleEditCancel}
         onSubmit={handleInputSubmit}
         onKeyDownCapture={handleKeyPress}
         flex={2}

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNode/StepNode.tsx
@@ -200,8 +200,6 @@ const StepNodeBase = ({
   const handleModalClose = () => {
     if (beforeCloseRef.current?.()) return
 
-    updateStep(indices, { ...step })
-
     refreshConnections(step)
 
     onModalClose()
@@ -211,8 +209,7 @@ const StepNodeBase = ({
   }
 
   const handleKeyUp = (content: TextBubbleContent) => {
-    const updatedStep = { ...step, content } as Step
-    updateStep(indices, updatedStep)
+    updateStep(indices, { content } as Partial<Step>)
   }
 
   const handleCloseEditor = () => {
@@ -237,7 +234,7 @@ const StepNodeBase = ({
   }
 
   const handleStepUpdate = (updates: Partial<Step>): void => {
-    updateStep(indices, { ...step, ...updates })
+    updateStep(indices, updates)
   }
 
   const hasErrorMessage = () => {

--- a/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/StepNodeContent/StepNodeContent.tsx
+++ b/apps/builder/components/shared/Graph/Nodes/StepNode/StepNodeContent/StepNodeContent/StepNodeContent.tsx
@@ -48,8 +48,9 @@ export const StepNodeContent = ({ step, indices }: Props) => {
   const handleStepUpdate = (options: StepOptions): void => {
     const stepWithOptions = step as StepWithOptions
     if (stepWithOptions.options) {
-      stepWithOptions.options = { ...stepWithOptions.options, ...options }
-      updateStep(indices, { ...stepWithOptions })
+      updateStep(indices, {
+        options: { ...stepWithOptions.options, ...options },
+      } as Partial<Step>)
     }
   }
 

--- a/apps/builder/contexts/TypebotContext/actions/steps.ts
+++ b/apps/builder/contexts/TypebotContext/actions/steps.ts
@@ -54,10 +54,10 @@ const stepsAction = (
         const step = typebot.blocks[blockIndex]?.steps[stepIndex]
         if (!step) return
 
-        const removedReferenceUpdates = JSON.parse(
-          JSON.stringify({ ...step, ...updates })
-        )
-        typebot.blocks[blockIndex].steps[stepIndex] = removedReferenceUpdates
+        typebot.blocks[blockIndex].steps[stepIndex] = {
+          ...step,
+          ...removeReferences(updates),
+        } as Step
       })
     ),
   duplicateStep: ({ blockIndex, stepIndex }: StepIndices) =>
@@ -83,6 +83,14 @@ const stepsAction = (
       })
     ),
 })
+
+const removeReferences = (updates: Partial<Omit<Step, 'id' | 'type'>>) =>
+  Object.entries(updates).reduce((clonedUpdates, [key, value]) => {
+    clonedUpdates[key] =
+      value === undefined ? undefined : JSON.parse(JSON.stringify(value))
+    return clonedUpdates
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }, {} as Record<string, any>)
 
 const removeStepFromBlock =
   ({ blockIndex, stepIndex }: StepIndices) =>


### PR DESCRIPTION
# Descrição

`ButtonNodeContent` mantém o texto da opção em estado local e só o envia para a store no `onSubmit` do `Editable` (blur). Um `useEffect` com dependência `[item]` ressincronizava esse estado sempre que a prop chegava com nova identidade — sem distinguir se o usuário estava digitando naquele instante.

A identidade do item mudava a cada `updateStep`, porque a action clonava o step inteiro com `JSON.parse(JSON.stringify({ ...step, ...updates }))`: uma alteração só em `options` já mintava novos objetos para todos os `items`. Dentro do modal de configuração, o editor da pergunta dispara `updateStep` por dois caminhos — o `useOutsideClick` do `TextBubbleEditor` (clicar na caixa da opção é "fora" dele) e o `onKeyUp` com debounce de 500ms. Quando esse commit caía depois do início da digitação, o effect sobrescrevia o estado local com o `content` antigo e o campo voltava ao placeholder, marcando erro de campo obrigatório.

É uma corrida: em máquina rápida a atualização commita antes da digitação e nada se perde. Só reproduz com CPU throttling (6x), bot grande ou aba sobrecarregada — o que explica o relato do cliente sem replicação interna.

`handleModalClose` era um segundo caminho de perda: gravava `updateStep(indices, { ...step })` com o `step` do closure de render, sobrescrevendo os items caso o `updateItem` do blur ainda não tivesse re-renderizado o `StepNode`.

- `ButtonNodeContent.tsx`: sincroniza a prop apenas fora de edição (`onEdit`/`onCancel`/`onSubmit`), depende de `item.content` em vez da identidade do objeto, e grava o texto pendente no unmount — cobre o fechamento do modal sem blur
- `actions/steps.ts`: `updateStep` clona apenas `updates` e mescla sobre o step da store, preservando chaves `undefined`; items mantêm identidade quando não mudam
- `StepNode/StepNode.tsx`: remove a escrita stale em `handleModalClose`; `handleKeyUp` e `handleStepUpdate` enviam patch parcial, não o step inteiro
- `StepNodeContent/StepNodeContent.tsx`: deixa de mutar `step.options` direto e envia apenas `options`
